### PR TITLE
feat: Turborepo caching and DAG parallelism in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,13 @@ variables:
 # Templates
 # ---------------------------------------------------------------------------
 
+.turbo-cache: &turbo-cache
+  cache:
+    key: turbo-${CI_COMMIT_REF_SLUG}
+    paths:
+      - .turbo/
+    policy: pull-push
+
 .cargo-cache: &cargo-cache
   cache:
     key: cargo-${CI_COMMIT_REF_SLUG}
@@ -58,7 +65,6 @@ prepare:deps:
   artifacts:
     paths:
       - node_modules/
-      - .turbo/
     expire_in: 1 hour
   timeout: 5 minutes
   <<: *rules-lint-test
@@ -71,6 +77,7 @@ lint:eslint:
   stage: lint
   image: oven/bun:1.2.17
   needs: ["prepare:deps"]
+  <<: *turbo-cache
   script:
     - bun lint
   timeout: 10 minutes
@@ -80,6 +87,7 @@ lint:typecheck:
   stage: lint
   image: oven/bun:1.2.17
   needs: ["prepare:deps"]
+  <<: *turbo-cache
   script:
     - bun type-check
   timeout: 10 minutes
@@ -93,6 +101,7 @@ test:frontend:
   stage: test
   image: oven/bun:1.2.17
   needs: ["prepare:deps"]
+  <<: *turbo-cache
   variables:
     JEST_JUNIT_OUTPUT_DIR: test-results
     JEST_JUNIT_OUTPUT_NAME: junit.xml
@@ -145,6 +154,7 @@ test:backend:
 build:frontend:
   stage: build
   image: docker:27
+  needs: ["lint:eslint", "lint:typecheck", "test:frontend"]
   <<: *docker-login
   script:
     - docker pull $CI_REGISTRY_IMAGE/frontend:$ENV_TAG-latest || true
@@ -209,6 +219,7 @@ build:frontend:
 build:admin:
   stage: build
   image: docker:27
+  needs: ["lint:eslint", "lint:typecheck"]
   <<: *docker-login
   script:
     - docker pull $CI_REGISTRY_IMAGE/admin:$ENV_TAG-latest || true


### PR DESCRIPTION
## Summary
- Add `.turbo-cache` GitLab cache template persisting `.turbo/` per branch — enables turbo task cache hits across pipeline runs
- Remove `.turbo/` from `prepare:deps` artifact (it was empty; `bun install` never runs turbo tasks, so saving it was a no-op that could overwrite real cache)
- Wire `build:frontend` and `build:admin` with explicit `needs` for true DAG parallelism — builds start as soon as their own gates clear, not after the entire test stage

## Test plan
- [ ] Trigger a pipeline on `development` and verify lint/test jobs restore/save `.turbo/` cache
- [ ] Trigger a second pipeline with no source changes — verify `>>> FULL TURBO` cache hits in lint/typecheck jobs
- [ ] Confirm `build:frontend` and `build:admin` start in parallel without waiting for `test:backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)