### PR TITLE
fix: harden chat attachment metadata handling

### DIFF
--- a/apps/admin-frontend/app/actions/chat.ts
+++ b/apps/admin-frontend/app/actions/chat.ts
@@ -2,12 +2,14 @@
 
 import { redirectOnForbidden } from '@/lib/api-error';
 import { createAdminApiClient } from '@/shared/api';
-import type {
-  AdminChatOverviewResp,
-  ChatConversation,
-  ChatMessage,
-  ChatStats,
-  ChatTopic,
+import {
+  normalizeChatMessage,
+  normalizeChatMessages,
+  type AdminChatOverviewResp,
+  type ChatConversation,
+  type ChatMessage,
+  type ChatStats,
+  type ChatTopic,
 } from '@/shared/api/chat';
 import type { ApiResponse } from '@/shared/utils/api-client';
 
@@ -48,12 +50,24 @@ export async function getConversation(id: string): Promise<ApiResponse<ChatConve
 
 export async function getMessages(id: string): Promise<ApiResponse<ChatMessage[]>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.get(`/api/admin/chat/conversations/${id}/messages`));
+  const res = check403(
+    await client.get<ChatMessage[]>(`/api/admin/chat/conversations/${id}/messages`)
+  );
+  if (res.success && Array.isArray(res.data)) {
+    return { ...res, data: normalizeChatMessages(res.data) };
+  }
+  return res;
 }
 
 export async function sendReply(id: string, content: string): Promise<ApiResponse<ChatMessage>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.post(`/api/admin/chat/conversations/${id}/messages`, { content }));
+  const res = check403(
+    await client.post<ChatMessage>(`/api/admin/chat/conversations/${id}/messages`, { content })
+  );
+  if (res.success && res.data) {
+    return { ...res, data: normalizeChatMessage(res.data) };
+  }
+  return res;
 }
 
 export async function assignAgent(id: string, agentAddress?: string): Promise<ApiResponse<ChatConversation>> {

--- a/apps/admin-frontend/components/chat/chat-conversation-view.tsx
+++ b/apps/admin-frontend/components/chat/chat-conversation-view.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { assignAgent, getMessages, markAsRead, sendReply, updateStatus } from '@/app/actions/chat';
-import type { ChatAttachment, ChatConversation, ChatMessage, ChatTopic } from '@/shared/api/chat';
+import {
+  getChatAttachments,
+  normalizeChatMessage,
+  type ChatAttachment,
+  type ChatConversation,
+  type ChatMessage,
+  type ChatTopic,
+} from '@/shared/api/chat';
 import { COOKIES } from '@/shared/auth/cookies';
 import { useSharedAuth } from '@/shared/components/auth';
 import { ChatMarkdown } from '@/shared/components/chat/chat-markdown';
@@ -79,7 +86,10 @@ async function uploadFile(convId: string, file: File): Promise<ChatMessage | nul
       body: form,
     });
     const json = await res.json() as { success?: boolean; data?: { message?: ChatMessage } };
-    return json.success === true ? (json.data?.message ?? null) : null;
+    if (json.success !== true || json.data?.message === undefined) {
+      return null;
+    }
+    return normalizeChatMessage(json.data.message);
   } catch { return null; }
 }
 
@@ -328,7 +338,7 @@ function MsgItem({ m, prev, readUpToId }: MsgItemProps) {
   const isSystem = m.sender_type === 'system';
   const isAi = m.sender_type === 'ai';
   const isRight = isAgent || isAi;
-  const attachments = m.metadata.attachments ?? [];
+  const attachments = getChatAttachments(m.metadata);
   const isAttachmentOnly = m.content.startsWith('[attachment:') && attachments.length > 0;
   const showDate = prev === undefined || formatDate(prev.created_at) !== formatDate(m.created_at);
   const isRead = isRight && (m.id === readUpToId || m.is_read === true);

--- a/apps/frontend/app/actions/chat.ts
+++ b/apps/frontend/app/actions/chat.ts
@@ -1,7 +1,12 @@
 'use server';
 
 import type { ChatConversation, ChatFullResp, ChatInboxResp, ChatMessage, ChatTopic } from '@/shared/api/chat';
-import { createSupportChatClient } from '@/shared/api/chat';
+import {
+  createSupportChatClient,
+  normalizeChatFullResp,
+  normalizeChatMessage,
+  normalizeChatMessages,
+} from '@/shared/api/chat';
 import { logger } from '@/shared/utils/logger';
 import { getServerActionClient } from '@/shared/utils/server-fetch';
 import { revalidatePath } from 'next/cache';
@@ -82,7 +87,7 @@ export async function getMessagesAction(id: string): Promise<ChatMessage[]> {
     const api = createSupportChatClient(client);
     const res = await api.getMessages(id);
     if (res.success && res.data) {
-      return res.data;
+      return normalizeChatMessages(res.data);
     }
     logger.debug('Messages fetch failed:', res);
   } catch (e) {
@@ -98,7 +103,7 @@ export async function sendMessageAction(id: string, content: string): Promise<Ch
     const res = await api.sendMessage(id, content);
     if (res.success && res.data) {
       revalidatePath(`/chat/${id}`);
-      return res.data;
+      return normalizeChatMessage(res.data);
     }
     logger.debug('Message send failed:', res);
   } catch (e) {
@@ -163,7 +168,10 @@ export async function uploadAttachmentAction(convId: string, formData: FormData)
       body: formData,
     });
     const json = await res.json() as { success?: boolean; data?: { message?: ChatMessage } };
-    return json.success === true ? (json.data?.message ?? null) : null;
+    if (json.success !== true || json.data?.message === undefined) {
+      return null;
+    }
+    return normalizeChatMessage(json.data.message);
   } catch (e) {
     logger.debug('Failed to upload attachment:', e);
     return null;
@@ -206,7 +214,7 @@ export async function getChatFullAction(id: string): Promise<ChatFullResp | null
     const api = createSupportChatClient(client);
     const res = await api.getConversationFull(id);
     if (res.success && res.data) {
-      return res.data;
+      return normalizeChatFullResp(res.data);
     }
     logger.debug('Chat full fetch failed:', res);
   } catch (e) {

--- a/shared/api/chat.ts
+++ b/shared/api/chat.ts
@@ -45,6 +45,57 @@ export interface ChatAttachment {
   size: number;
 }
 
+export type ChatMessageMetadata =
+  | ({ attachments?: ChatAttachment[] } & Record<string, unknown>)
+  | null;
+
+type NormalizedChatMessageMetadata = {
+  attachments?: ChatAttachment[];
+} & Record<string, unknown>;
+
+function isChatAttachment(value: unknown): value is ChatAttachment {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const attachment = value as Partial<ChatAttachment>;
+
+  return (
+    typeof attachment.url === 'string' &&
+    typeof attachment.filename === 'string' &&
+    typeof attachment.file_type === 'string' &&
+    typeof attachment.size === 'number'
+  );
+}
+
+function isChatMessageMetadataRecord(
+  value: unknown
+): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function normalizeChatMessageMetadata(
+  metadata: ChatMessageMetadata | undefined
+): NormalizedChatMessageMetadata {
+  if (!isChatMessageMetadataRecord(metadata)) {
+    return {};
+  }
+
+  const attachments = Array.isArray(metadata.attachments)
+    ? metadata.attachments.filter(isChatAttachment)
+    : undefined;
+
+  return attachments === undefined
+    ? { ...metadata }
+    : { ...metadata, attachments };
+}
+
+export function getChatAttachments(
+  metadata: ChatMessageMetadata | undefined
+): ChatAttachment[] {
+  return normalizeChatMessageMetadata(metadata).attachments ?? [];
+}
+
 export interface ChatMessage {
   id: string;
   conversation_id: string;
@@ -52,7 +103,7 @@ export interface ChatMessage {
   sender_address: string | null;
   content: string;
   is_read: boolean;
-  metadata: { attachments?: ChatAttachment[] } & Record<string, unknown>;
+  metadata: ChatMessageMetadata;
   created_at: string;
 }
 
@@ -95,6 +146,30 @@ export interface ChatFullResp {
   messages: ChatMessage[];
 }
 
+export function normalizeChatMessage(message: ChatMessage): ChatMessage {
+  return {
+    ...message,
+    metadata: normalizeChatMessageMetadata(message.metadata),
+  };
+}
+
+export function normalizeChatMessages(
+  messages: ChatMessage[] | null | undefined
+): ChatMessage[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  return messages.map(normalizeChatMessage);
+}
+
+export function normalizeChatFullResp(chatFull: ChatFullResp): ChatFullResp {
+  return {
+    ...chatFull,
+    messages: normalizeChatMessages(chatFull.messages),
+  };
+}
+
 export interface AdminChatOverviewResp {
   stats: ChatStats;
   conversations: ChatConversation[];
@@ -106,7 +181,7 @@ export interface AdminChatOverviewResp {
 // ============================================================================
 
 export class SupportChatApi {
-  constructor(private client: UnifiedApiClient) { }
+  constructor(private client: UnifiedApiClient) {}
 
   // Topics
   async getTopics(): Promise<ApiResponse<ChatTopic[]>> {
@@ -114,7 +189,9 @@ export class SupportChatApi {
   }
 
   // User conversations
-  async createConversation(data: CreateConversationReq): Promise<ApiResponse<ChatConversation>> {
+  async createConversation(
+    data: CreateConversationReq
+  ): Promise<ApiResponse<ChatConversation>> {
     return this.client.post('/api/chat/conversations', data);
   }
 
@@ -130,11 +207,19 @@ export class SupportChatApi {
     return this.client.get(`/api/chat/conversations/${id}/messages`);
   }
 
-  async sendMessage(id: string, content: string): Promise<ApiResponse<ChatMessage>> {
-    return this.client.post(`/api/chat/conversations/${id}/messages`, { content });
+  async sendMessage(
+    id: string,
+    content: string
+  ): Promise<ApiResponse<ChatMessage>> {
+    return this.client.post(`/api/chat/conversations/${id}/messages`, {
+      content,
+    });
   }
 
-  async updateStatus(id: string, status: string): Promise<ApiResponse<ChatConversation>> {
+  async updateStatus(
+    id: string,
+    status: string
+  ): Promise<ApiResponse<ChatConversation>> {
     return this.client.put(`/api/chat/conversations/${id}/status`, { status });
   }
 
@@ -161,14 +246,24 @@ export class SupportChatApi {
     agent?: string;
   }): Promise<ApiResponse<ChatConversation[]>> {
     const searchParams = new URLSearchParams();
-    if (params?.status !== undefined && params.status !== '') { searchParams.set('status', params.status); }
-    if (params?.topic_id !== undefined && params.topic_id !== '') { searchParams.set('topic_id', params.topic_id); }
-    if (params?.agent !== undefined && params.agent !== '') { searchParams.set('agent', params.agent); }
+    if (params?.status !== undefined && params.status !== '') {
+      searchParams.set('status', params.status);
+    }
+    if (params?.topic_id !== undefined && params.topic_id !== '') {
+      searchParams.set('topic_id', params.topic_id);
+    }
+    if (params?.agent !== undefined && params.agent !== '') {
+      searchParams.set('agent', params.agent);
+    }
     const qs = searchParams.toString();
-    return this.client.get(`/api/admin/chat/conversations${qs !== '' ? `?${qs}` : ''}`);
+    return this.client.get(
+      `/api/admin/chat/conversations${qs !== '' ? `?${qs}` : ''}`
+    );
   }
 
-  async adminGetConversation(id: string): Promise<ApiResponse<ChatConversation>> {
+  async adminGetConversation(
+    id: string
+  ): Promise<ApiResponse<ChatConversation>> {
     return this.client.get(`/api/admin/chat/conversations/${id}`);
   }
 
@@ -176,16 +271,31 @@ export class SupportChatApi {
     return this.client.get(`/api/admin/chat/conversations/${id}/messages`);
   }
 
-  async adminSendReply(id: string, content: string): Promise<ApiResponse<ChatMessage>> {
-    return this.client.post(`/api/admin/chat/conversations/${id}/messages`, { content });
+  async adminSendReply(
+    id: string,
+    content: string
+  ): Promise<ApiResponse<ChatMessage>> {
+    return this.client.post(`/api/admin/chat/conversations/${id}/messages`, {
+      content,
+    });
   }
 
-  async adminAssignAgent(id: string, agentAddress?: string): Promise<ApiResponse<ChatConversation>> {
-    return this.client.put(`/api/admin/chat/conversations/${id}/assign`, { agent_address: agentAddress });
+  async adminAssignAgent(
+    id: string,
+    agentAddress?: string
+  ): Promise<ApiResponse<ChatConversation>> {
+    return this.client.put(`/api/admin/chat/conversations/${id}/assign`, {
+      agent_address: agentAddress,
+    });
   }
 
-  async adminUpdateStatus(id: string, status: string): Promise<ApiResponse<ChatConversation>> {
-    return this.client.put(`/api/admin/chat/conversations/${id}/status`, { status });
+  async adminUpdateStatus(
+    id: string,
+    status: string
+  ): Promise<ApiResponse<ChatConversation>> {
+    return this.client.put(`/api/admin/chat/conversations/${id}/status`, {
+      status,
+    });
   }
 
   async adminMarkRead(id: string): Promise<ApiResponse<void>> {
@@ -209,6 +319,8 @@ export class SupportChatApi {
 // FACTORY
 // ============================================================================
 
-export function createSupportChatClient(client: UnifiedApiClient): SupportChatApi {
+export function createSupportChatClient(
+  client: UnifiedApiClient
+): SupportChatApi {
   return new SupportChatApi(client);
 }

--- a/shared/hooks/use-chat-sse.ts
+++ b/shared/hooks/use-chat-sse.ts
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
-import type { ChatMessage, ChatConversation } from '../api/chat';
+import {
+  normalizeChatMessage,
+  type ChatMessage,
+  type ChatConversation,
+} from '../api/chat';
 import { COOKIES } from '../auth/cookies';
 import { API_ROUTES } from '../config/route-constants';
 
@@ -105,6 +109,9 @@ export function useChatSSE({ enabled, mode, onEvent }: UseChatSSEOpts) {
     es.addEventListener(eventName, (e: MessageEvent) => {
       try {
         const data = JSON.parse(e.data as string) as ChatSSEEvent;
+        if (data.type === 'new_message' && data.message !== undefined) {
+          data.message = normalizeChatMessage(data.message);
+        }
         onEventRef.current?.(data);
         retryRef.current = 0;
       } catch { /* invalid payload */ }

--- a/tests/unit/frontend/shared/api/chat.test.ts
+++ b/tests/unit/frontend/shared/api/chat.test.ts
@@ -1,0 +1,100 @@
+import {
+  getChatAttachments,
+  normalizeChatMessage,
+  normalizeChatMessageMetadata,
+} from '@/shared/api/chat';
+
+describe('getChatAttachments', () => {
+  it('returns an empty array when metadata is null', () => {
+    expect(getChatAttachments(null)).toEqual([]);
+  });
+
+  it('returns an empty array when attachments are missing', () => {
+    expect(getChatAttachments({})).toEqual([]);
+  });
+
+  it('returns an empty array when attachments are null', () => {
+    expect(getChatAttachments({ attachments: null } as any)).toEqual([]);
+  });
+
+  it('returns an empty array when metadata is a primitive', () => {
+    expect(getChatAttachments('bad-payload' as any)).toEqual([]);
+  });
+
+  it('filters malformed attachments out of the response payload', () => {
+    expect(
+      getChatAttachments({
+        attachments: [
+          {
+            url: 'https://cdn.epsx.io/chat/1/file.png',
+            filename: 'file.png',
+            file_type: 'image/png',
+            size: 2048,
+          },
+          {
+            url: 'https://cdn.epsx.io/chat/1/bad.png',
+            filename: 'bad.png',
+          },
+        ],
+      } as any)
+    ).toEqual([
+      {
+        url: 'https://cdn.epsx.io/chat/1/file.png',
+        filename: 'file.png',
+        file_type: 'image/png',
+        size: 2048,
+      },
+    ]);
+  });
+});
+
+describe('normalizeChatMessageMetadata', () => {
+  it('coerces null metadata to an empty object', () => {
+    expect(normalizeChatMessageMetadata(null)).toEqual({});
+  });
+
+  it('keeps non-attachment metadata fields while sanitizing attachments', () => {
+    expect(
+      normalizeChatMessageMetadata({
+        note: 'hello',
+        attachments: [
+          {
+            url: 'https://cdn.epsx.io/chat/1/file.png',
+            filename: 'file.png',
+            file_type: 'image/png',
+            size: 2048,
+          },
+          { filename: 'broken.png' },
+        ],
+      } as any)
+    ).toEqual({
+      note: 'hello',
+      attachments: [
+        {
+          url: 'https://cdn.epsx.io/chat/1/file.png',
+          filename: 'file.png',
+          file_type: 'image/png',
+          size: 2048,
+        },
+      ],
+    });
+  });
+});
+
+describe('normalizeChatMessage', () => {
+  it('replaces null metadata so direct attachment access is safe', () => {
+    const message = normalizeChatMessage({
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      sender_type: 'user',
+      sender_address: null,
+      content: 'hello',
+      is_read: false,
+      metadata: null,
+      created_at: '2026-04-19T00:00:00.000Z',
+    });
+
+    expect(message.metadata).toEqual({});
+    expect(message.metadata?.attachments).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed
- normalize support chat message metadata before the UI reads attachment fields
- sanitize message payloads loaded through admin actions, frontend actions, uploads, and SSE events
- add frontend unit coverage for null and malformed attachment metadata

## Why
The admin chat page could crash with `Cannot read properties of null (reading 'attachments')` when older or malformed chat message metadata arrived as `null` instead of an object.

## Impact
- fixes the admin chat support crash
- keeps frontend and admin chat attachment rendering resilient to malformed payloads

## Validation
- `bunx jest --selectProjects frontend tests/unit/frontend/shared/api/chat.test.ts --runInBand`
- `bunx tsc -p apps/frontend/tsconfig.json --noEmit` currently fails on pre-existing `shared/utils/url-resolver.ts` errors already present on top of `origin/development`
- `bunx tsc -p apps/admin-frontend/tsconfig.json --noEmit` currently fails on the same pre-existing `shared/utils/url-resolver.ts` errors
