### PR TITLE
Handle missing promotion end dates in pricing cards

### DIFF
--- a/shared/utils/promo.ts
+++ b/shared/utils/promo.ts
@@ -6,6 +6,38 @@ import { fmtAmt } from './formatting/currency'
 export type PromoType = 'percentage' | 'fixed';
 export type PromoStatus = 'active' | 'upcoming' | 'expired' | 'disabled';
 
+const DEFAULT_PROMOTION_FALLBACK_YEARS = 1;
+
+function parsePromotionDate(value: string): Date | null {
+  const trimmedValue = value.trim();
+  if (trimmedValue === '') {
+    return null;
+  }
+
+  const parsedDate = new Date(trimmedValue);
+  return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+}
+
+function getFallbackPromotionEndDate(now: Date): Date {
+  const fallbackDate = new Date(now);
+  fallbackDate.setFullYear(fallbackDate.getFullYear() + DEFAULT_PROMOTION_FALLBACK_YEARS);
+  return fallbackDate;
+}
+
+export function resolvePromotionEndDate(
+  endDate: string | null | undefined,
+  now: Date = new Date()
+): Date {
+  if (typeof endDate === 'string') {
+    const parsedDate = parsePromotionDate(endDate);
+    if (parsedDate !== null) {
+      return parsedDate;
+    }
+  }
+
+  return getFallbackPromotionEndDate(now);
+}
+
 /**
  * Options for calculating price
  */
@@ -96,7 +128,7 @@ export function formatBadge(
  */
 export function getTimeRemaining(endDate: string): string {
   const now = new Date();
-  const end = new Date(endDate);
+  const end = resolvePromotionEndDate(endDate, now);
   const diff = end.getTime() - now.getTime();
 
   if (diff <= 0) {

--- a/tests/unit/frontend/shared/utils/promo.test.ts
+++ b/tests/unit/frontend/shared/utils/promo.test.ts
@@ -1,0 +1,35 @@
+import { getTimeRemaining, resolvePromotionEndDate } from '@/shared/utils/promo';
+
+describe('resolvePromotionEndDate', () => {
+  it('falls back to one year from now when the promotion end date is blank', () => {
+    const now = new Date('2026-04-20T03:25:45.234Z');
+
+    expect(resolvePromotionEndDate('', now).toISOString()).toBe(
+      '2027-04-20T03:25:45.234Z'
+    );
+  });
+
+  it('keeps valid promotion end dates unchanged', () => {
+    const now = new Date('2026-04-20T03:25:45.234Z');
+    const expectedEndDate = '2026-12-31T00:00:00.000Z';
+
+    expect(resolvePromotionEndDate(expectedEndDate, now).toISOString()).toBe(
+      expectedEndDate
+    );
+  });
+});
+
+describe('getTimeRemaining', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('uses the one-year fallback window instead of returning NaN when the end date is blank', () => {
+    expect(getTimeRemaining('')).toBe('365d left');
+  });
+});


### PR DESCRIPTION
## Summary
- add a safe fallback when `promotion_ends_at` is blank or invalid
- treat missing promotion end dates as one year from the current time in the pricing countdown
- add a unit test covering the fallback and preserving valid dates

## Verification
- `./node_modules/.bin/jest --config jest.config.js --selectProjects frontend --runTestsByPath tests/unit/frontend/shared/utils/promo.test.ts`
- verified the live `https://epsx.io/plans` page renders `Ends in 365d` and no longer shows `NaN`

## Notes
- the production hotfix has already been deployed to `epsx.io`