### PR TITLE
feat: add design bypass mode for protected app flows

### DIFF
--- a/apps/admin-frontend/app/actions/chat.ts
+++ b/apps/admin-frontend/app/actions/chat.ts
@@ -13,14 +13,17 @@ import {
 } from '@/shared/api/chat';
 import type { ApiResponse } from '@/shared/utils/api-client';
 
-function check403<T>(res: ApiResponse<T>, route = '/chat'): ApiResponse<T> {
-  redirectOnForbidden(res, route);
+async function check403<T>(
+  res: ApiResponse<T>,
+  route = '/chat'
+): Promise<ApiResponse<T>> {
+  await redirectOnForbidden(res, route);
   return res;
 }
 
 export async function getAdminChatStats(): Promise<ApiResponse<ChatStats>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.get('/api/admin/chat/stats'));
+  return await check403(await client.get('/api/admin/chat/stats'));
 }
 
 export async function listAllConversations(
@@ -40,18 +43,30 @@ export async function listAllConversations(
     params.set('agent', agent);
   }
   const qs = params.toString();
-  return check403(await client.get(`/api/admin/chat/conversations${qs !== '' ? `?${qs}` : ''}`));
+  return await check403(
+    await client.get(
+      `/api/admin/chat/conversations${qs !== '' ? `?${qs}` : ''}`
+    )
+  );
 }
 
-export async function getConversation(id: string): Promise<ApiResponse<ChatConversation>> {
+export async function getConversation(
+  id: string
+): Promise<ApiResponse<ChatConversation>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.get(`/api/admin/chat/conversations/${id}`));
+  return await check403(
+    await client.get(`/api/admin/chat/conversations/${id}`)
+  );
 }
 
-export async function getMessages(id: string): Promise<ApiResponse<ChatMessage[]>> {
+export async function getMessages(
+  id: string
+): Promise<ApiResponse<ChatMessage[]>> {
   const client = createAdminApiClient({ serverSide: true });
-  const res = check403(
-    await client.get<ChatMessage[]>(`/api/admin/chat/conversations/${id}/messages`)
+  const res = await check403(
+    await client.get<ChatMessage[]>(
+      `/api/admin/chat/conversations/${id}/messages`
+    )
   );
   if (res.success && Array.isArray(res.data)) {
     return { ...res, data: normalizeChatMessages(res.data) };
@@ -59,10 +74,16 @@ export async function getMessages(id: string): Promise<ApiResponse<ChatMessage[]
   return res;
 }
 
-export async function sendReply(id: string, content: string): Promise<ApiResponse<ChatMessage>> {
+export async function sendReply(
+  id: string,
+  content: string
+): Promise<ApiResponse<ChatMessage>> {
   const client = createAdminApiClient({ serverSide: true });
-  const res = check403(
-    await client.post<ChatMessage>(`/api/admin/chat/conversations/${id}/messages`, { content })
+  const res = await check403(
+    await client.post<ChatMessage>(
+      `/api/admin/chat/conversations/${id}/messages`,
+      { content }
+    )
   );
   if (res.success && res.data) {
     return { ...res, data: normalizeChatMessage(res.data) };
@@ -70,29 +91,45 @@ export async function sendReply(id: string, content: string): Promise<ApiRespons
   return res;
 }
 
-export async function assignAgent(id: string, agentAddress?: string): Promise<ApiResponse<ChatConversation>> {
+export async function assignAgent(
+  id: string,
+  agentAddress?: string
+): Promise<ApiResponse<ChatConversation>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.put(`/api/admin/chat/conversations/${id}/assign`, { agent_address: agentAddress }));
+  return await check403(
+    await client.put(`/api/admin/chat/conversations/${id}/assign`, {
+      agent_address: agentAddress,
+    })
+  );
 }
 
-export async function updateStatus(id: string, status: string): Promise<ApiResponse<ChatConversation>> {
+export async function updateStatus(
+  id: string,
+  status: string
+): Promise<ApiResponse<ChatConversation>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.put(`/api/admin/chat/conversations/${id}/status`, { status }));
+  return await check403(
+    await client.put(`/api/admin/chat/conversations/${id}/status`, { status })
+  );
 }
 
 export async function markAsRead(id: string): Promise<ApiResponse<void>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.put(`/api/admin/chat/conversations/${id}/read`, {}));
+  return await check403(
+    await client.put(`/api/admin/chat/conversations/${id}/read`, {})
+  );
 }
 
 export async function getTopics(): Promise<ApiResponse<ChatTopic[]>> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.get('/api/admin/chat/topics'));
+  return await check403(await client.get('/api/admin/chat/topics'));
 }
 
-export async function getAdminChatOverview(): Promise<ApiResponse<AdminChatOverviewResp>> {
+export async function getAdminChatOverview(): Promise<
+  ApiResponse<AdminChatOverviewResp>
+> {
   const client = createAdminApiClient({ serverSide: true });
-  return check403(await client.get('/api/admin/chat/overview'));
+  return await check403(await client.get('/api/admin/chat/overview'));
 }
 
 export interface AdminAgent {
@@ -101,14 +138,18 @@ export interface AdminAgent {
   status: string;
 }
 
-export async function listAdminAgents(search?: string): Promise<ApiResponse<AdminAgent[]>> {
+export async function listAdminAgents(
+  search?: string
+): Promise<ApiResponse<AdminAgent[]>> {
   const client = createAdminApiClient({ serverSide: true });
   const params: Record<string, string> = { limit: '50', status: 'active' };
   if (search !== undefined && search !== '') {
     params.search = search;
   }
   const qs = new URLSearchParams(params).toString();
-  const res = await client.get<{ users: AdminAgent[]; total_count: number }>(`/api/admin/users?${qs}`);
+  const res = await client.get<{ users: AdminAgent[]; total_count: number }>(
+    `/api/admin/users?${qs}`
+  );
   if (res.success && res.data) {
     return { ...res, data: res.data.users };
   }

--- a/apps/admin-frontend/app/analytics/actions.ts
+++ b/apps/admin-frontend/app/analytics/actions.ts
@@ -1,13 +1,13 @@
 'use server';
 
 import type {
-    ApiKeysResponse,
-    DeveloperPortalStats,
-    PermissionAnalytics,
-    PlanStats,
-    RecentWalletsData,
-    SystemMetrics,
-    UserStats
+  ApiKeysResponse,
+  DeveloperPortalStats,
+  PermissionAnalytics,
+  PlanStats,
+  RecentWalletsData,
+  SystemMetrics,
+  UserStats,
 } from '@/hooks/use-analytics-data';
 import { redirectOnForbidden, rethrowRedirect } from '@/lib/api-error';
 import { logout } from '@/lib/auth/auth';
@@ -17,159 +17,187 @@ import type { UnifiedApiClient } from '@/shared/utils/api-client';
 import { logger } from '@/lib/logger';
 
 async function processApiResponse<T>(
-    res: ApiResponse<T>,
-    errorMessage: string,
-    defaultValue?: T
+  res: ApiResponse<T>,
+  errorMessage: string,
+  defaultValue?: T
 ): Promise<T> {
-    if (!res.success) {
-        redirectOnForbidden(res, '/analytics');
+  if (!res.success) {
+    await redirectOnForbidden(res, '/analytics');
 
-        const isUnauth = res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED';
+    const isUnauth =
+      res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED';
 
-        if (!isUnauth) {
-            logger.action.error(errorMessage, res.error, { code: res.error?.code });
-        }
-
-        if (defaultValue !== undefined) {
-            return defaultValue;
-        }
-
-        if (isUnauth) {
-            await logout();
-        }
-
-        throw new Error(res.error?.message ?? errorMessage);
+    if (!isUnauth) {
+      logger.action.error(errorMessage, res.error, { code: res.error?.code });
     }
 
-    return res.data ?? (defaultValue as T);
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
+
+    if (isUnauth) {
+      await logout();
+    }
+
+    throw new Error(res.error?.message ?? errorMessage);
+  }
+
+  return res.data ?? (defaultValue as T);
 }
 
 function processApiError<T>(
-    error: unknown,
-    errorMessage: string,
-    defaultValue?: T
+  error: unknown,
+  errorMessage: string,
+  defaultValue?: T
 ): T {
-    rethrowRedirect(error);
+  rethrowRedirect(error);
 
-    logger.error(`${errorMessage}:`, error instanceof Error ? error.message : String(error));
+  logger.error(
+    `${errorMessage}:`,
+    error instanceof Error ? error.message : String(error)
+  );
 
-    if (defaultValue !== undefined) {
-        return defaultValue;
-    }
+  if (defaultValue !== undefined) {
+    return defaultValue;
+  }
 
-    throw error as Error;
+  throw error as Error;
 }
 
 async function handleAction<T>(
-    requestFn: (apiClient: UnifiedApiClient) => Promise<ApiResponse<T>>,
-    errorMessage: string,
-    defaultValue?: T
+  requestFn: (apiClient: UnifiedApiClient) => Promise<ApiResponse<T>>,
+  errorMessage: string,
+  defaultValue?: T
 ): Promise<T> {
-    const apiClient = createAdminApiClient({ serverSide: true });
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    try {
-        const res = await requestFn(apiClient);
-        return await processApiResponse(res, errorMessage, defaultValue);
-    } catch (error: unknown) {
-        return processApiError(error, errorMessage, defaultValue);
-    }
+  try {
+    const res = await requestFn(apiClient);
+    return await processApiResponse(res, errorMessage, defaultValue);
+  } catch (error: unknown) {
+    return processApiError(error, errorMessage, defaultValue);
+  }
 }
 
 export async function getUserStatsAction(): Promise<UserStats> {
-    return handleAction(
-        (apiClient) => apiClient.get<UserStats>('/api/admin/wallets/stats'),
-        'Failed to fetch user stats',
-        {} as UserStats
-    );
+  return handleAction(
+    apiClient => apiClient.get<UserStats>('/api/admin/wallets/stats'),
+    'Failed to fetch user stats',
+    {} as UserStats
+  );
 }
 
 export async function getPermissionAnalyticsAction(): Promise<PermissionAnalytics> {
-    return handleAction(
-        (apiClient) => apiClient.get<PermissionAnalytics>('/api/admin/analytics/permissions'),
-        'Failed to fetch permission analytics',
-        {} as PermissionAnalytics
-    );
+  return handleAction(
+    apiClient =>
+      apiClient.get<PermissionAnalytics>('/api/admin/analytics/permissions'),
+    'Failed to fetch permission analytics',
+    {} as PermissionAnalytics
+  );
 }
 
 export async function getSystemMetricsAction(): Promise<SystemMetrics> {
-    return handleAction(
-        (apiClient) => apiClient.get<SystemMetrics>('/api/admin/analytics/metrics'),
-        'Failed to fetch system metrics',
-        {} as SystemMetrics
-    );
+  return handleAction(
+    apiClient => apiClient.get<SystemMetrics>('/api/admin/analytics/metrics'),
+    'Failed to fetch system metrics',
+    {} as SystemMetrics
+  );
 }
 
 export async function getDeveloperPortalStatsAction(): Promise<DeveloperPortalStats> {
-    return handleAction(
-        (apiClient) => apiClient.get<DeveloperPortalStats>('/api/admin/developer-portal/stats'),
-        'Failed to fetch developer portal stats',
-        {
-            total_api_keys: 0,
-            active_api_keys: 0,
-            revoked_api_keys: 0,
-            expired_api_keys: 0,
-            total_modules: 0,
-            active_modules: 0,
-            total_requests_today: 0,
-            total_requests_this_month: 0,
-            top_modules_by_usage: []
-        }
-    );
+  return handleAction(
+    apiClient =>
+      apiClient.get<DeveloperPortalStats>('/api/admin/developer-portal/stats'),
+    'Failed to fetch developer portal stats',
+    {
+      total_api_keys: 0,
+      active_api_keys: 0,
+      revoked_api_keys: 0,
+      expired_api_keys: 0,
+      total_modules: 0,
+      active_modules: 0,
+      total_requests_today: 0,
+      total_requests_this_month: 0,
+      top_modules_by_usage: [],
+    }
+  );
 }
 
 export async function getApiKeysAction(): Promise<ApiKeysResponse> {
-    return handleAction(
-        (apiClient) => apiClient.get<ApiKeysResponse>('/api/admin/developer-portal/api-keys'),
-        'Failed to fetch API keys',
-        { keys: [] }
-    );
+  return handleAction(
+    apiClient =>
+      apiClient.get<ApiKeysResponse>('/api/admin/developer-portal/api-keys'),
+    'Failed to fetch API keys',
+    { keys: [] }
+  );
 }
 
-export async function getRecentWalletsAction(limit = 10, days = 30): Promise<RecentWalletsData> {
-    return handleAction(
-        (apiClient) => apiClient.get<RecentWalletsData>(`/api/admin/web3/recent-wallets?limit=${limit}&days=${days}`),
-        'Failed to fetch recent wallets',
-        { recent_wallets: [], analytics: { total_in_period: 0, daily_breakdown: [], period_days: days, avg_daily: 0 }, metadata: { limit, total_count: 0, has_more: false, generated_at: new Date().toISOString() } }
-    );
+export async function getRecentWalletsAction(
+  limit = 10,
+  days = 30
+): Promise<RecentWalletsData> {
+  return handleAction(
+    apiClient =>
+      apiClient.get<RecentWalletsData>(
+        `/api/admin/web3/recent-wallets?limit=${limit}&days=${days}`
+      ),
+    'Failed to fetch recent wallets',
+    {
+      recent_wallets: [],
+      analytics: {
+        total_in_period: 0,
+        daily_breakdown: [],
+        period_days: days,
+        avg_daily: 0,
+      },
+      metadata: {
+        limit,
+        total_count: 0,
+        has_more: false,
+        generated_at: new Date().toISOString(),
+      },
+    }
+  );
 }
 
 export async function getPlanStatsAction(): Promise<PlanStats> {
-    return handleAction(
-        async (apiClient) => {
-            const plansClient = createPlansClient(apiClient);
-            return await plansClient.getStats();
-        },
-        'Failed to fetch plan stats',
-        {
-            total_plans: 0,
-            active_plans: 0,
-            total_memberships: 0,
-            active_memberships: 0,
-            by_plan: {},
-            recent_assignments: 0,
-            recent_removals: 0
-        }
-    );
+  return handleAction(
+    async apiClient => {
+      const plansClient = createPlansClient(apiClient);
+      return await plansClient.getStats();
+    },
+    'Failed to fetch plan stats',
+    {
+      total_plans: 0,
+      active_plans: 0,
+      total_memberships: 0,
+      active_memberships: 0,
+      by_plan: {},
+      recent_assignments: 0,
+      recent_removals: 0,
+    }
+  );
 }
 
 export interface AdminAnalyticsDashboard {
-    user_stats: UserStats | null;
-    permission_analytics: PermissionAnalytics | null;
-    plan_stats: PlanStats | null;
-    system_metrics: SystemMetrics | null;
-    developer_portal: DeveloperPortalStats | null;
+  user_stats: UserStats | null;
+  permission_analytics: PermissionAnalytics | null;
+  plan_stats: PlanStats | null;
+  system_metrics: SystemMetrics | null;
+  developer_portal: DeveloperPortalStats | null;
 }
 
 export async function getAnalyticsDashboardAction(): Promise<AdminAnalyticsDashboard> {
-    return handleAction(
-        (apiClient) => apiClient.get<AdminAnalyticsDashboard>('/api/admin/analytics/dashboard'),
-        'Failed to fetch analytics dashboard',
-        {
-            user_stats: null,
-            permission_analytics: null,
-            plan_stats: null,
-            system_metrics: null,
-            developer_portal: null,
-        }
-    );
+  return handleAction(
+    apiClient =>
+      apiClient.get<AdminAnalyticsDashboard>('/api/admin/analytics/dashboard'),
+    'Failed to fetch analytics dashboard',
+    {
+      user_stats: null,
+      permission_analytics: null,
+      plan_stats: null,
+      system_metrics: null,
+      developer_portal: null,
+    }
+  );
 }

--- a/apps/admin-frontend/app/audit-log/actions.ts
+++ b/apps/admin-frontend/app/audit-log/actions.ts
@@ -6,54 +6,66 @@ import { API_ROUTES } from '@/shared/config/route-constants';
 import type { ActionType, AuditLogEntry } from './types';
 
 interface FetchAuditLogsParams {
-    page: number;
-    pageSize: number;
-    search?: string;
-    category?: ActionType;
-    fromDate?: string;
-    toDate?: string;
+  page: number;
+  pageSize: number;
+  search?: string;
+  category?: ActionType;
+  fromDate?: string;
+  toDate?: string;
 }
 
-function buildAuditQueryParams(params: FetchAuditLogsParams): Record<string, string> {
-    const q: Record<string, string> = {
-        page: params.page.toString(),
-        page_size: params.pageSize.toString(),
-    };
-    if (params.search !== undefined && params.search !== '') { q.search = params.search; }
-    if (params.category !== undefined && params.category !== 'all') { q.category = params.category; }
-    if (params.fromDate !== undefined && params.fromDate !== '') { q.from_date = params.fromDate; }
-    if (params.toDate !== undefined && params.toDate !== '') { q.to_date = params.toDate; }
-    return q;
+function buildAuditQueryParams(
+  params: FetchAuditLogsParams
+): Record<string, string> {
+  const q: Record<string, string> = {
+    page: params.page.toString(),
+    page_size: params.pageSize.toString(),
+  };
+  if (params.search !== undefined && params.search !== '') {
+    q.search = params.search;
+  }
+  if (params.category !== undefined && params.category !== 'all') {
+    q.category = params.category;
+  }
+  if (params.fromDate !== undefined && params.fromDate !== '') {
+    q.from_date = params.fromDate;
+  }
+  if (params.toDate !== undefined && params.toDate !== '') {
+    q.to_date = params.toDate;
+  }
+  return q;
 }
 
-export async function fetchAuditLogsAction(params: FetchAuditLogsParams): Promise<{
-    success: boolean;
-    entries: AuditLogEntry[];
-    totalPages: number;
-    error?: string;
+export async function fetchAuditLogsAction(
+  params: FetchAuditLogsParams
+): Promise<{
+  success: boolean;
+  entries: AuditLogEntry[];
+  totalPages: number;
+  error?: string;
 }> {
-    const client = createAdminApiClient({ serverSide: true });
-    const qs = new URLSearchParams(buildAuditQueryParams(params));
+  const client = createAdminApiClient({ serverSide: true });
+  const qs = new URLSearchParams(buildAuditQueryParams(params));
 
-    const res = await client.get<{
-        entries: AuditLogEntry[];
-        total_pages: number;
-    }>(`${API_ROUTES.ADMIN.AUDIT_LOGS}?${qs.toString()}`);
+  const res = await client.get<{
+    entries: AuditLogEntry[];
+    total_pages: number;
+  }>(`${API_ROUTES.ADMIN.AUDIT_LOGS}?${qs.toString()}`);
 
-    if (res.success && res.data) {
-        return {
-            success: true,
-            entries: res.data.entries,
-            totalPages: res.data.total_pages,
-        };
-    }
-
-    redirectOnForbidden(res, '/audit-log');
-
+  if (res.success && res.data) {
     return {
-        success: false,
-        entries: [],
-        totalPages: 0,
-        error: res.error?.message ?? 'Failed to load audit logs',
+      success: true,
+      entries: res.data.entries,
+      totalPages: res.data.total_pages,
     };
+  }
+
+  await redirectOnForbidden(res, '/audit-log');
+
+  return {
+    success: false,
+    entries: [],
+    totalPages: 0,
+    error: res.error?.message ?? 'Failed to load audit logs',
+  };
 }

--- a/apps/admin-frontend/app/payments/actions.ts
+++ b/apps/admin-frontend/app/payments/actions.ts
@@ -4,32 +4,36 @@ import { redirectOnForbidden } from '@/lib/api-error';
 import { createAdminApiClient } from '@/shared/api';
 import type { ApiResponse } from '@/shared/utils/api-client';
 
-function check403<T>(res: ApiResponse<T>): ApiResponse<T> {
-    redirectOnForbidden(res, '/payments');
-    return res;
+async function check403<T>(res: ApiResponse<T>): Promise<ApiResponse<T>> {
+  await redirectOnForbidden(res, '/payments');
+  return res;
 }
 
 export async function fetchPaymentsAction(params: Record<string, string>) {
-    const client = createAdminApiClient({ serverSide: true });
-    return check403(await client.get('/api/payments/admin/list', params));
+  const client = createAdminApiClient({ serverSide: true });
+  return await check403(await client.get('/api/payments/admin/list', params));
 }
 
 export async function fetchUserAccessAction(params: Record<string, string>) {
-    const client = createAdminApiClient({ serverSide: true });
-    return check403(await client.get('/api/admin/plans/user-access/list', params));
+  const client = createAdminApiClient({ serverSide: true });
+  return await check403(
+    await client.get('/api/admin/plans/user-access/list', params)
+  );
 }
 
 export async function fetchPaymentLinksAction(params: Record<string, string>) {
-    const client = createAdminApiClient({ serverSide: true });
-    return check403(await client.get('/api/admin/payment-links', params));
+  const client = createAdminApiClient({ serverSide: true });
+  return await check403(await client.get('/api/admin/payment-links', params));
 }
 
-export async function createPaymentLinkAction(payload: Record<string, unknown>) {
-    const client = createAdminApiClient({ serverSide: true });
-    return check403(await client.post('/api/admin/payment-links', payload));
+export async function createPaymentLinkAction(
+  payload: Record<string, unknown>
+) {
+  const client = createAdminApiClient({ serverSide: true });
+  return await check403(await client.post('/api/admin/payment-links', payload));
 }
 
 export async function deletePaymentLinkAction(id: string) {
-    const client = createAdminApiClient({ serverSide: true });
-    return check403(await client.delete(`/api/admin/payment-links/${id}`));
+  const client = createAdminApiClient({ serverSide: true });
+  return await check403(await client.delete(`/api/admin/payment-links/${id}`));
 }

--- a/apps/admin-frontend/app/policies/actions.ts
+++ b/apps/admin-frontend/app/policies/actions.ts
@@ -5,70 +5,81 @@ import { logout } from '@/lib/auth/auth';
 import { createAdminApiClient } from '@/shared/api';
 
 interface PolicyStats {
-    total_policies: number;
-    active_policies: number;
-    policies_by_type: Record<string, number>;
-    evaluations_24h: number;
-    avg_evaluation_time_ms: number;
-    decision_breakdown: Record<string, number>;
+  total_policies: number;
+  active_policies: number;
+  policies_by_type: Record<string, number>;
+  evaluations_24h: number;
+  avg_evaluation_time_ms: number;
+  decision_breakdown: Record<string, number>;
 }
 
 export async function getPolicyStatsAction(): Promise<PolicyStats | null> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<{ stats: PolicyStats }>('/api/admin/policies/stats');
-    if (!res.success) {
-        redirectOnForbidden(res, '/policies');
-        if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
-            await logout();
-        }
-        return null;
-    }
-    if (res.data) {
-        return res.data.stats;
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<{ stats: PolicyStats }>(
+    '/api/admin/policies/stats'
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, '/policies');
+    if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
+      await logout();
     }
     return null;
+  }
+  if (res.data) {
+    return res.data.stats;
+  }
+  return null;
 }
 
 export async function getPolicyTemplatesAction(): Promise<unknown[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<{ templates: unknown[] }>('/api/admin/policies/templates');
-    if (!res.success) {
-        redirectOnForbidden(res, '/policies');
-        if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
-            await logout();
-        }
-        return [];
-    }
-    if (res.data) {
-        return res.data.templates;
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<{ templates: unknown[] }>(
+    '/api/admin/policies/templates'
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, '/policies');
+    if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
+      await logout();
     }
     return [];
+  }
+  if (res.data) {
+    return res.data.templates;
+  }
+  return [];
 }
 
-export async function evaluatePolicyAction(context: Record<string, unknown>): Promise<unknown> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post<{ evaluation: unknown }>('/api/admin/policies/evaluate', context);
-    if (!res.success) {
-        redirectOnForbidden(res, '/policies');
-        if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
-            await logout();
-        }
-        throw new Error(res.error?.message ?? 'Failed to evaluate policy');
+export async function evaluatePolicyAction(
+  context: Record<string, unknown>
+): Promise<unknown> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post<{ evaluation: unknown }>(
+    '/api/admin/policies/evaluate',
+    context
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, '/policies');
+    if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
+      await logout();
     }
-    if (res.data) {
-        return res.data.evaluation;
-    }
-    throw new Error('Failed to evaluate policy: No data');
+    throw new Error(res.error?.message ?? 'Failed to evaluate policy');
+  }
+  if (res.data) {
+    return res.data.evaluation;
+  }
+  throw new Error('Failed to evaluate policy: No data');
 }
 
-export async function createPolicyAction(formData: Record<string, unknown>): Promise<void> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post('/api/admin/policies', formData);
-    if (!res.success) {
-        redirectOnForbidden(res, '/policies');
-        if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
-            await logout();
-        }
-        throw new Error(res.error?.message ?? 'Failed to save policy');
+export async function createPolicyAction(
+  formData: Record<string, unknown>
+): Promise<void> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post('/api/admin/policies', formData);
+  if (!res.success) {
+    await redirectOnForbidden(res, '/policies');
+    if (res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED') {
+      await logout();
     }
+    throw new Error(res.error?.message ?? 'Failed to save policy');
+  }
 }

--- a/apps/admin-frontend/app/wallet-management/actions.ts
+++ b/apps/admin-frontend/app/wallet-management/actions.ts
@@ -1,12 +1,10 @@
 'use server';
 
+import type { WalletFilters } from '@/components/wallet/types';
 import type {
-    WalletFilters
-} from '@/components/wallet/types';
-import type {
-    DisableWalletRequest,
-    EnableWalletRequest,
-    WalletListResponse
+  DisableWalletRequest,
+  EnableWalletRequest,
+  WalletListResponse,
 } from '@/lib/api/wallet-management-client';
 import { redirectOnForbidden } from '@/lib/api-error';
 import { logout } from '@/lib/auth/auth';
@@ -21,117 +19,152 @@ import { mapWalletDtoToData } from '@/lib/mappers/wallet';
 const WALLET_MGMT_ROUTE = '/wallet-management';
 
 // Helper to check and handle auth errors
-async function checkAuthError(error?: { code?: string; message?: string } | null) {
-    if (!error) { return; }
+async function checkAuthError(
+  error?: { code?: string; message?: string } | null
+) {
+  if (!error) {
+    return;
+  }
 
-    // Fix: Remove unnecessary optional chain if message is known to be string when error exists
-    // But safely, message might be missing in some error shapes.
-    const isUnauthorized = error.code === 'UNAUTHORIZED'
-        || error.code === '401'
-        || (error.message?.includes('Unauthorized') ?? false);
+  // Fix: Remove unnecessary optional chain if message is known to be string when error exists
+  // But safely, message might be missing in some error shapes.
+  const isUnauthorized =
+    error.code === 'UNAUTHORIZED' ||
+    error.code === '401' ||
+    (error.message?.includes('Unauthorized') ?? false);
 
-    if (isUnauthorized) {
-        await logout();
-    }
+  if (isUnauthorized) {
+    await logout();
+  }
 }
 
 // Helper to build query params
-function buildQueryParams(filters: WalletFilters, page: number, limit: number): Record<string, string> {
-    const params: Record<string, string> = {
-        page: page.toString(),
-        limit: limit.toString(),
-        sort_by: filters.sortBy,
-        sort_order: filters.sortOrder,
-    };
-    if (filters.search !== '') { params['search'] = filters.search; }
-    if (filters.status !== 'all') { params['status'] = filters.status === 'disabled' ? 'inactive' : filters.status; }
-    return params;
+function buildQueryParams(
+  filters: WalletFilters,
+  page: number,
+  limit: number
+): Record<string, string> {
+  const params: Record<string, string> = {
+    page: page.toString(),
+    limit: limit.toString(),
+    sort_by: filters.sortBy,
+    sort_order: filters.sortOrder,
+  };
+  if (filters.search !== '') {
+    params['search'] = filters.search;
+  }
+  if (filters.status !== 'all') {
+    params['status'] =
+      filters.status === 'disabled' ? 'inactive' : filters.status;
+  }
+  return params;
 }
 
 // Helper to extract data handling different response formats
 function extractWalletsData(rawData: WalletListResponse) {
-    const internalData = rawData.data;
+  const internalData = rawData.data;
 
-    // Use internal data if generally available, otherwise fallback to root properties
-    // The conditional usage of ?? handles the case where internalData is undefined
-    let rawWallets = rawData.wallets;
-    if (internalData?.wallets) {
-        rawWallets = internalData.wallets;
-    }
-    const wallets = rawWallets.map(mapWalletDtoToData);
+  // Use internal data if generally available, otherwise fallback to root properties
+  // The conditional usage of ?? handles the case where internalData is undefined
+  let rawWallets = rawData.wallets;
+  if (internalData?.wallets) {
+    rawWallets = internalData.wallets;
+  }
+  const wallets = rawWallets.map(mapWalletDtoToData);
 
-    let pagination = rawData.pagination;
-    if (internalData?.pagination) {
-        pagination = internalData.pagination;
-    }
+  let pagination = rawData.pagination;
+  if (internalData?.pagination) {
+    pagination = internalData.pagination;
+  }
 
-    pagination ??= {
-        page: 1,
-        limit: 9,
-        total: wallets.length,
-        total_pages: 1,
-        has_next_page: false,
-        has_previous_page: false
-    };
+  pagination ??= {
+    page: 1,
+    limit: 9,
+    total: wallets.length,
+    total_pages: 1,
+    has_next_page: false,
+    has_previous_page: false,
+  };
 
-    return { wallets, pagination };
+  return { wallets, pagination };
 }
 
-export async function fetchWalletsAction(filters: WalletFilters, page = 1, limit = 20) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const params = buildQueryParams(filters, page, limit);
+export async function fetchWalletsAction(
+  filters: WalletFilters,
+  page = 1,
+  limit = 20
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const params = buildQueryParams(filters, page, limit);
 
-    const res = await apiClient.get<WalletListResponse>('/api/admin/wallets', params);
+  const res = await apiClient.get<WalletListResponse>(
+    '/api/admin/wallets',
+    params
+  );
 
-    if (!res.success) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        await checkAuthError(res.error);
-        const msg = res.error?.message ?? 'Failed to fetch wallets';
-        const code = res.error?.code ?? 'UNKNOWN';
-        return { success: false as const, error: `${msg} (${code})` };
-    }
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    await checkAuthError(res.error);
+    const msg = res.error?.message ?? 'Failed to fetch wallets';
+    const code = res.error?.code ?? 'UNKNOWN';
+    return { success: false as const, error: `${msg} (${code})` };
+  }
 
-    const rawData = res.data;
-    if (!rawData) {
-        return { success: false as const, error: 'No data returned' };
-    }
+  const rawData = res.data;
+  if (!rawData) {
+    return { success: false as const, error: 'No data returned' };
+  }
 
-    return { success: true as const, ...extractWalletsData(rawData) };
+  return { success: true as const, ...extractWalletsData(rawData) };
 }
 
-export async function updateWalletMetadataAction(walletAddress: string, data: { label?: string | null; note?: string | null }) {
-    const apiClient = createAdminApiClient({ serverSide: true });
+export async function updateWalletMetadataAction(
+  walletAddress: string,
+  data: { label?: string | null; note?: string | null }
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    const res = await apiClient.put(`/api/admin/wallets/${walletAddress}`, {
-        metadata: { label: data.label ?? undefined, note: data.note ?? undefined },
-    });
+  const res = await apiClient.put(`/api/admin/wallets/${walletAddress}`, {
+    metadata: { label: data.label ?? undefined, note: data.note ?? undefined },
+  });
 
-    if (!res.success) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        await checkAuthError(res.error);
-        throw new Error(res.error?.message ?? 'Failed to update metadata');
-    }
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    await checkAuthError(res.error);
+    throw new Error(res.error?.message ?? 'Failed to update metadata');
+  }
 }
 
-export async function disableWalletAction(walletAddress: string, data: DisableWalletRequest) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post(`/api/admin/wallets/${walletAddress}/disable`, data);
+export async function disableWalletAction(
+  walletAddress: string,
+  data: DisableWalletRequest
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post(
+    `/api/admin/wallets/${walletAddress}/disable`,
+    data
+  );
 
-    if (!res.success) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        await checkAuthError(res.error);
-        throw new Error(res.error?.message ?? 'Failed to disable wallet');
-    }
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    await checkAuthError(res.error);
+    throw new Error(res.error?.message ?? 'Failed to disable wallet');
+  }
 }
 
-export async function enableWalletAction(walletAddress: string, data: EnableWalletRequest) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post(`/api/admin/wallets/${walletAddress}/enable`, data);
+export async function enableWalletAction(
+  walletAddress: string,
+  data: EnableWalletRequest
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post(
+    `/api/admin/wallets/${walletAddress}/enable`,
+    data
+  );
 
-    if (!res.success) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        await checkAuthError(res.error);
-        throw new Error(res.error?.message ?? 'Failed to enable wallet');
-    }
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    await checkAuthError(res.error);
+    throw new Error(res.error?.message ?? 'Failed to enable wallet');
+  }
 }
-

--- a/apps/admin-frontend/app/wallet-management/credits/actions.ts
+++ b/apps/admin-frontend/app/wallet-management/credits/actions.ts
@@ -19,9 +19,10 @@ async function handleApiError<T>(
   errMsg: string,
   defaultVal?: T
 ): Promise<T> {
-  redirectOnForbidden(res, '/wallet-management/credits');
+  await redirectOnForbidden(res, '/wallet-management/credits');
 
-  const isUnauth = res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED';
+  const isUnauth =
+    res.error?.code === '401' || res.error?.code === 'UNAUTHORIZED';
 
   if (isUnauth) {
     await logout();
@@ -54,7 +55,10 @@ async function handleAction<T>(
   } catch (error: unknown) {
     rethrowRedirect(error);
 
-    logger.error(`${errMsg}:`, error instanceof Error ? error.message : String(error));
+    logger.error(
+      `${errMsg}:`,
+      error instanceof Error ? error.message : String(error)
+    );
 
     if (defaultVal !== undefined) {
       return defaultVal;
@@ -66,7 +70,7 @@ async function handleAction<T>(
 
 export async function getCreditStatsAction(): Promise<CreditStats> {
   return handleAction(
-    (apiClient) => {
+    apiClient => {
       const creditsApi = createCreditsApi(apiClient);
       return creditsApi.adminGetStats();
     },
@@ -86,35 +90,26 @@ export async function getUserCreditsAction(
   walletAddress: string,
   filters?: CreditTransactionFilters
 ) {
-  return handleAction(
-    (apiClient) => {
-      const creditsApi = createCreditsApi(apiClient);
-      return creditsApi.adminGetUserCredits(walletAddress, filters);
-    },
-    'Failed to fetch user credits'
-  );
+  return handleAction(apiClient => {
+    const creditsApi = createCreditsApi(apiClient);
+    return creditsApi.adminGetUserCredits(walletAddress, filters);
+  }, 'Failed to fetch user credits');
 }
 
 export async function grantCreditsAction(
   request: GrantCreditsRequest
 ): Promise<{ transaction_id: string; new_balance: number }> {
-  return handleAction(
-    (apiClient) => {
-      const creditsApi = createCreditsApi(apiClient);
-      return creditsApi.adminGrantCredits(request);
-    },
-    'Failed to grant credits'
-  );
+  return handleAction(apiClient => {
+    const creditsApi = createCreditsApi(apiClient);
+    return creditsApi.adminGrantCredits(request);
+  }, 'Failed to grant credits');
 }
 
 export async function revokeCreditsAction(
   request: RevokeCreditsRequest
 ): Promise<{ transaction_id: string; new_balance: number }> {
-  return handleAction(
-    (apiClient) => {
-      const creditsApi = createCreditsApi(apiClient);
-      return creditsApi.adminRevokeCredits(request);
-    },
-    'Failed to revoke credits'
-  );
+  return handleAction(apiClient => {
+    const creditsApi = createCreditsApi(apiClient);
+    return creditsApi.adminRevokeCredits(request);
+  }, 'Failed to revoke credits');
 }

--- a/apps/admin-frontend/app/wallet-management/plan-actions.ts
+++ b/apps/admin-frontend/app/wallet-management/plan-actions.ts
@@ -2,11 +2,11 @@
 
 import { redirectOnForbidden } from '@/lib/api-error';
 import type {
-    AssignmentDto,
-    CreatePlanRequest,
-    PermissionPlan,
-    UpdatePlanRequest,
-    UserPlanMembership
+  AssignmentDto,
+  CreatePlanRequest,
+  PermissionPlan,
+  UpdatePlanRequest,
+  UserPlanMembership,
 } from '@/lib/api/plan-management-client';
 import { createAdminApiClient, extractArrayOrEmpty } from '@/shared/api';
 import { API_ROUTES } from '@/shared/config/route-constants';
@@ -17,10 +17,10 @@ import { revalidatePath } from 'next/cache';
 // ============================================================================
 
 import type {
-    DisableWalletRequest,
-    EnableWalletRequest,
-    WalletData,
-    WalletSummaryDto
+  DisableWalletRequest,
+  EnableWalletRequest,
+  WalletData,
+  WalletSummaryDto,
 } from '@/lib/api/wallet-management-client';
 import { mapWalletDtoToData } from '@/lib/mappers/wallet';
 import type { RawPlanData } from '@/types/wallet';
@@ -35,29 +35,31 @@ const WALLET_MGMT_ROUTE = '/wallet-management';
 // HELPER FUNCTIONS
 // ============================================================================
 
-function mapAssignmentToMembership(assignment: AssignmentDto): UserPlanMembership {
-    return {
-        id: assignment.id,
-        user_id: assignment.wallet_address,
-        plan_id: assignment.plan_id,
-        granted_by: assignment.assigned_by ?? 'system',
-        granted_at: assignment.assigned_at,
-        expires_at: assignment.expires_at,
-        is_active: assignment.is_active,
-        plan: {
-            id: assignment.plan_id,
-            name: assignment.plan_name,
-            slug: assignment.plan_slug ?? '',
-            description: assignment.plan_description ?? assignment.plan_type ?? '',
-            plan_type: assignment.plan_type ?? 'manual',
-            permissions: [],
-            is_active: true,
-            created_at: assignment.assigned_at,
-            updated_at: assignment.assigned_at,
-            default_expiry_days: assignment.default_expiry_days,
-            tier_level: assignment.priority_level ?? 0,
-        } as unknown as PermissionPlan
-    };
+function mapAssignmentToMembership(
+  assignment: AssignmentDto
+): UserPlanMembership {
+  return {
+    id: assignment.id,
+    user_id: assignment.wallet_address,
+    plan_id: assignment.plan_id,
+    granted_by: assignment.assigned_by ?? 'system',
+    granted_at: assignment.assigned_at,
+    expires_at: assignment.expires_at,
+    is_active: assignment.is_active,
+    plan: {
+      id: assignment.plan_id,
+      name: assignment.plan_name,
+      slug: assignment.plan_slug ?? '',
+      description: assignment.plan_description ?? assignment.plan_type ?? '',
+      plan_type: assignment.plan_type ?? 'manual',
+      permissions: [],
+      is_active: true,
+      created_at: assignment.assigned_at,
+      updated_at: assignment.assigned_at,
+      default_expiry_days: assignment.default_expiry_days,
+      tier_level: assignment.priority_level ?? 0,
+    } as unknown as PermissionPlan,
+  };
 }
 
 // ============================================================================
@@ -65,220 +67,326 @@ function mapAssignmentToMembership(assignment: AssignmentDto): UserPlanMembershi
 // ============================================================================
 
 export async function getAvailablePermissionsAction(): Promise<string[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<string[]>('/api/admin/permissions/available');
-    return extractArrayOrEmpty<string>(res);
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<string[]>('/api/admin/permissions/available');
+  return extractArrayOrEmpty<string>(res);
 }
 
 export async function getPlansAction(): Promise<PermissionPlan[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<PermissionPlan[]>(API_ROUTES.PERMISSIONS.PLANS);
-    return extractArrayOrEmpty<PermissionPlan>(res);
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<PermissionPlan[]>(
+    API_ROUTES.PERMISSIONS.PLANS
+  );
+  return extractArrayOrEmpty<PermissionPlan>(res);
 }
 
-export async function getUserPlansAction(userId: string): Promise<UserPlanMembership[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<AssignmentDto[]>(API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS, {
-        wallet_address: userId,
-        is_active: true,
-        limit: 100,
-    });
-    return extractArrayOrEmpty<AssignmentDto>(res).map(mapAssignmentToMembership);
-}
-
-export async function getPlanMembershipsAction(planId: string): Promise<UserPlanMembership[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<AssignmentDto[]>(API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS, {
-        plan_id: planId,
-        is_active: true,
-        limit: 100,
-    });
-    return extractArrayOrEmpty<AssignmentDto>(res).map(mapAssignmentToMembership);
-}
-
-export async function getUserPermissionsAction(userId: string): Promise<string[]> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<string[]>(`/api/auth/web3/plans/permissions/${userId}`);
-    if (!res.success) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        if (res.error?.code === '404') { return []; }
+export async function getUserPlansAction(
+  userId: string
+): Promise<UserPlanMembership[]> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<AssignmentDto[]>(
+    API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS,
+    {
+      wallet_address: userId,
+      is_active: true,
+      limit: 100,
     }
-    return res.data ?? [];
+  );
+  return extractArrayOrEmpty<AssignmentDto>(res).map(mapAssignmentToMembership);
 }
 
-export async function grantPermissionAction(walletAddress: string, permission: string, expiresAt?: string) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post('/api/admin/permissions/direct/grant', {
-        wallet_address: walletAddress,
-        permission_string: permission,
-        expires_at: expiresAt,
-    });
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to grant permission'); }
+export async function getPlanMembershipsAction(
+  planId: string
+): Promise<UserPlanMembership[]> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<AssignmentDto[]>(
+    API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS,
+    {
+      plan_id: planId,
+      is_active: true,
+      limit: 100,
+    }
+  );
+  return extractArrayOrEmpty<AssignmentDto>(res).map(mapAssignmentToMembership);
 }
 
-export async function revokePermissionAction(walletAddress: string, permission: string) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    // Use POST as per client implementation
-    const res = await apiClient.post('/api/admin/permissions/direct/revoke', {
-        wallet_address: walletAddress,
-        permission_string: permission,
-    });
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to revoke permission'); }
+export async function getUserPermissionsAction(
+  userId: string
+): Promise<string[]> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<string[]>(
+    `/api/auth/web3/plans/permissions/${userId}`
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    if (res.error?.code === '404') {
+      return [];
+    }
+  }
+  return res.data ?? [];
 }
 
-export async function assignUserToPlanAction(userId: string, planId: string, expiresAt?: string | null) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post(API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS, {
-        wallet_address: userId,
-        plan_id: planId,
-        expires_at: expiresAt,
-        assignment_source: 'manual',
-    });
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to assign plan'); }
+export async function grantPermissionAction(
+  walletAddress: string,
+  permission: string,
+  expiresAt?: string
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post('/api/admin/permissions/direct/grant', {
+    wallet_address: walletAddress,
+    permission_string: permission,
+    expires_at: expiresAt,
+  });
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to grant permission');
+  }
+}
+
+export async function revokePermissionAction(
+  walletAddress: string,
+  permission: string
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  // Use POST as per client implementation
+  const res = await apiClient.post('/api/admin/permissions/direct/revoke', {
+    wallet_address: walletAddress,
+    permission_string: permission,
+  });
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to revoke permission');
+  }
+}
+
+export async function assignUserToPlanAction(
+  userId: string,
+  planId: string,
+  expiresAt?: string | null
+) {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post(API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS, {
+    wallet_address: userId,
+    plan_id: planId,
+    expires_at: expiresAt,
+    assignment_source: 'manual',
+  });
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to assign plan');
+  }
 }
 
 export async function removeUserFromPlanAction(userId: string, planId: string) {
-    const apiClient = createAdminApiClient({ serverSide: true });
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    // First get the assignment ID
-    const assignments = await getUserPlansAction(userId);
-    const assignment = assignments.find(a => a.plan_id === planId);
+  // First get the assignment ID
+  const assignments = await getUserPlansAction(userId);
+  const assignment = assignments.find(a => a.plan_id === planId);
 
-    if (assignment) {
-        const res = await apiClient.delete(`${API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS}/${assignment.id}`);
-        if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to remove plan'); }
+  if (assignment) {
+    const res = await apiClient.delete(
+      `${API_ROUTES.ADMIN.PERMISSION_ASSIGNMENTS}/${assignment.id}`
+    );
+    if (!res.success) {
+      await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+      throw new Error(res.error?.message ?? 'Failed to remove plan');
     }
+  }
 }
 
-export async function updatePlanAction(planId: string, data: UpdatePlanRequest): Promise<PermissionPlan> {
-    const apiClient = createAdminApiClient({ serverSide: true });
+export async function updatePlanAction(
+  planId: string,
+  data: UpdatePlanRequest
+): Promise<PermissionPlan> {
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    // Pass tier_level directly to backend
-    const payload = {
-        ...data,
-    };
+  // Pass tier_level directly to backend
+  const payload = {
+    ...data,
+  };
 
-    const res = await apiClient.put<PermissionPlan>(`${API_ROUTES.PERMISSIONS.PLANS}/${planId}`, payload);
-    if (!res.success || !res.data) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        throw new Error(res.error?.message ?? 'Failed to update plan');
-    }
-    revalidatePath('/wallet-management/access/plans', 'layout');
-    return res.data;
+  const res = await apiClient.put<PermissionPlan>(
+    `${API_ROUTES.PERMISSIONS.PLANS}/${planId}`,
+    payload
+  );
+  if (!res.success || !res.data) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to update plan');
+  }
+  revalidatePath('/wallet-management/access/plans', 'layout');
+  return res.data;
 }
 
-export async function createPlanAction(data: CreatePlanRequest): Promise<PermissionPlan> {
-    const apiClient = createAdminApiClient({ serverSide: true });
+export async function createPlanAction(
+  data: CreatePlanRequest
+): Promise<PermissionPlan> {
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    const slug = data.name
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .trim();
+  const slug = data.name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
 
-    const backendRequest = {
-        name: data.name,
-        slug,
-        description: data.description ?? '',
-        plan_type: 'subscription',
-        permissions: data.permissions,
-        tier_level: data.tier_level,
-        price: data.price,
-        plan_group: data.plan_group,
-    };
+  const backendRequest = {
+    name: data.name,
+    slug,
+    description: data.description ?? '',
+    plan_type: 'subscription',
+    permissions: data.permissions,
+    tier_level: data.tier_level,
+    price: data.price,
+    plan_group: data.plan_group,
+  };
 
-    const res = await apiClient.post<PermissionPlan>(API_ROUTES.PERMISSIONS.PLANS, backendRequest);
-    if (!res.success || !res.data) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        throw new Error(res.error?.message ?? 'Failed to create plan');
-    }
+  const res = await apiClient.post<PermissionPlan>(
+    API_ROUTES.PERMISSIONS.PLANS,
+    backendRequest
+  );
+  if (!res.success || !res.data) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to create plan');
+  }
 
-    revalidatePath('/wallet-management/access/plans');
-    return res.data;
+  revalidatePath('/wallet-management/access/plans');
+  return res.data;
 }
 
 export async function getPlanAction(planId: string): Promise<PermissionPlan> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.get<PermissionPlan>(`${API_ROUTES.PERMISSIONS.PLANS}/${planId}`);
-    if (!res.success || !res.data) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to fetch plan'); }
-    return res.data;
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.get<PermissionPlan>(
+    `${API_ROUTES.PERMISSIONS.PLANS}/${planId}`
+  );
+  if (!res.success || !res.data) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to fetch plan');
+  }
+  return res.data;
 }
 
 export async function deletePlanAction(planId: string) {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.delete(`${API_ROUTES.PERMISSIONS.PLANS}/${planId}`);
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to delete plan'); }
-    revalidatePath('/wallet-management/access/plans');
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.delete(
+    `${API_ROUTES.PERMISSIONS.PLANS}/${planId}`
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to delete plan');
+  }
+  revalidatePath('/wallet-management/access/plans');
 }
 
-export async function fetchWalletDetailAction(walletAddress: string): Promise<WalletData> {
-    const apiClient = createAdminApiClient({ serverSide: true });
+export async function fetchWalletDetailAction(
+  walletAddress: string
+): Promise<WalletData> {
+  const apiClient = createAdminApiClient({ serverSide: true });
 
-    // We expect either a wrapped { wallet: ... } or a flat WalletSummaryDto
-    const res = await apiClient.get<Record<string, unknown>>(`/api/admin/wallets/${walletAddress}`);
+  // We expect either a wrapped { wallet: ... } or a flat WalletSummaryDto
+  const res = await apiClient.get<Record<string, unknown>>(
+    `/api/admin/wallets/${walletAddress}`
+  );
 
-    if (!res.success || !res.data) {
-        redirectOnForbidden(res, WALLET_MGMT_ROUTE);
-        throw new Error(res.error?.message ?? 'Wallet not found');
-    }
+  if (!res.success || !res.data) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Wallet not found');
+  }
 
-    const data = res.data;
+  const data = res.data;
 
-    // Check if it's wrapped in `wallet` property
-    if (typeof data.wallet === 'object' && data.wallet !== null) {
-        return mapWalletDtoToData(data.wallet as WalletSummaryDto);
-    }
+  // Check if it's wrapped in `wallet` property
+  if (typeof data.wallet === 'object' && data.wallet !== null) {
+    return mapWalletDtoToData(data.wallet as WalletSummaryDto);
+  }
 
-    // Check if it looks like a flat wallet object (has wallet_address)
-    if (typeof data.wallet_address === 'string') {
-        return mapWalletDtoToData(data as unknown as WalletSummaryDto);
-    }
+  // Check if it looks like a flat wallet object (has wallet_address)
+  if (typeof data.wallet_address === 'string') {
+    return mapWalletDtoToData(data as unknown as WalletSummaryDto);
+  }
 
-    throw new Error('Wallet not found');
+  throw new Error('Wallet not found');
 }
 
-export async function updateWalletMetadataAction(walletAddress: string, data: { label?: string | null; note?: string | null }): Promise<void> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.put(`/api/admin/wallets/${walletAddress}`, {
-        metadata: { label: data.label ?? undefined, note: data.note ?? undefined },
-    });
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to update metadata'); }
+export async function updateWalletMetadataAction(
+  walletAddress: string,
+  data: { label?: string | null; note?: string | null }
+): Promise<void> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.put(`/api/admin/wallets/${walletAddress}`, {
+    metadata: { label: data.label ?? undefined, note: data.note ?? undefined },
+  });
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to update metadata');
+  }
 }
 
-export async function disableWalletAction(walletAddress: string, data: DisableWalletRequest): Promise<void> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post(`/api/admin/wallets/${walletAddress}/disable`, data);
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to disable wallet'); }
+export async function disableWalletAction(
+  walletAddress: string,
+  data: DisableWalletRequest
+): Promise<void> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post(
+    `/api/admin/wallets/${walletAddress}/disable`,
+    data
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to disable wallet');
+  }
 }
 
-export async function enableWalletAction(walletAddress: string, data: EnableWalletRequest): Promise<void> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    const res = await apiClient.post(`/api/admin/wallets/${walletAddress}/enable`, data);
-    if (!res.success) { redirectOnForbidden(res, WALLET_MGMT_ROUTE); throw new Error(res.error?.message ?? 'Failed to enable wallet'); }
+export async function enableWalletAction(
+  walletAddress: string,
+  data: EnableWalletRequest
+): Promise<void> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  const res = await apiClient.post(
+    `/api/admin/wallets/${walletAddress}/enable`,
+    data
+  );
+  if (!res.success) {
+    await redirectOnForbidden(res, WALLET_MGMT_ROUTE);
+    throw new Error(res.error?.message ?? 'Failed to enable wallet');
+  }
 }
 
 export interface WalletAccessSummary {
-    available_permissions: string[];
-    available_plans: RawPlanData[];
-    wallet_permissions: string[];
-    wallet_assignments: Array<{
-        plan_id: string;
-        plan_name: string;
-        expires_at: string | null;
-        granted_at: string | null;
-    }>;
+  available_permissions: string[];
+  available_plans: RawPlanData[];
+  wallet_permissions: string[];
+  wallet_assignments: Array<{
+    plan_id: string;
+    plan_name: string;
+    expires_at: string | null;
+    granted_at: string | null;
+  }>;
 }
 
-export async function getWalletAccessSummaryAction(walletAddress: string): Promise<WalletAccessSummary> {
-    const apiClient = createAdminApiClient({ serverSide: true });
-    try {
-        const res = await apiClient.get<WalletAccessSummary>(`/api/admin/wallets/${walletAddress}/access-summary`);
-        if (!res.success || !res.data) {
-            return { available_permissions: [], available_plans: [], wallet_permissions: [], wallet_assignments: [] };
-        }
-        return res.data;
-    } catch {
-        return { available_permissions: [], available_plans: [], wallet_permissions: [], wallet_assignments: [] };
+export async function getWalletAccessSummaryAction(
+  walletAddress: string
+): Promise<WalletAccessSummary> {
+  const apiClient = createAdminApiClient({ serverSide: true });
+  try {
+    const res = await apiClient.get<WalletAccessSummary>(
+      `/api/admin/wallets/${walletAddress}/access-summary`
+    );
+    if (!res.success || !res.data) {
+      return {
+        available_permissions: [],
+        available_plans: [],
+        wallet_permissions: [],
+        wallet_assignments: [],
+      };
     }
+    return res.data;
+  } catch {
+    return {
+      available_permissions: [],
+      available_plans: [],
+      wallet_permissions: [],
+      wallet_assignments: [],
+    };
+  }
 }

--- a/apps/admin-frontend/lib/api-error.ts
+++ b/apps/admin-frontend/lib/api-error.ts
@@ -1,10 +1,18 @@
 import { redirect } from 'next/navigation';
+import { isDesignBypassServerEnabled } from '@/shared/utils/design-bypass';
 
 /** Redirect to /access-denied if response is 403 */
-export function redirectOnForbidden(
-  res: { success: boolean; error?: { status?: number; message?: string } | null },
+export async function redirectOnForbidden(
+  res: {
+    success: boolean;
+    error?: { status?: number; message?: string } | null;
+  },
   route: string
-): void {
+): Promise<void> {
+  if (await isDesignBypassServerEnabled()) {
+    return;
+  }
+
   if (!res.success && res.error?.status === 403) {
     const params = new URLSearchParams({
       route: encodeURIComponent(route),
@@ -17,5 +25,7 @@ export function redirectOnForbidden(
 
 /** Re-throw Next.js redirect errors (have `digest` property) */
 export function rethrowRedirect(e: unknown): void {
-  if (typeof e === 'object' && e !== null && 'digest' in e) {throw e;}
+  if (typeof e === 'object' && e !== null && 'digest' in e) {
+    throw e;
+  }
 }

--- a/apps/admin-frontend/lib/auth/auth.ts
+++ b/apps/admin-frontend/lib/auth/auth.ts
@@ -5,6 +5,12 @@
  */
 
 import { COOKIES } from '@/shared/auth/cookies';
+import {
+  DESIGN_BYPASS_WALLET,
+  getDesignBypassPermissions,
+  isDesignBypassEnabled,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 import { logger } from '@/lib/logger';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -59,6 +65,45 @@ interface UserCookieData {
   auth_time?: string;
 }
 
+function createDesignBypassWeb3Session(): Web3SessionData {
+  return {
+    walletAddress: DESIGN_BYPASS_WALLET,
+    signature: '',
+    message: '',
+    nonce: '',
+    chainId: 56,
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  };
+}
+
+function parseUserCookieData(userCookie: string): UserCookieData | null {
+  try {
+    return JSON.parse(decodeURIComponent(userCookie)) as UserCookieData;
+  } catch (parseError) {
+    logger.auth.error('Failed to parse user cookie', {
+      parseError: String(parseError),
+    });
+    return null;
+  }
+}
+
+function getWalletAddress(userData: UserCookieData): string {
+  return userData.wallet_address ?? userData.sub ?? '';
+}
+
+function getDefaultChainId(): number {
+  const defaultChainId = process.env['NEXT_PUBLIC_DEFAULT_CHAIN_ID'];
+  return defaultChainId !== undefined && defaultChainId !== ''
+    ? parseInt(defaultChainId)
+    : 56;
+}
+
+function getSessionExpiry(userData: UserCookieData, fallbackTime: number): number {
+  return userData.auth_time !== undefined
+    ? parseInt(userData.auth_time) + 2592000000
+    : fallbackTime + 2592000000;
+}
+
 // ============================================================================
 // Web3 Session Management
 // ============================================================================
@@ -67,6 +112,10 @@ interface UserCookieData {
  * Get Web3 authentication data from EPSX HttpOnly cookies
  */
 export async function getWeb3SessionFromCookies(): Promise<Web3SessionData | null> {
+  if (await isDesignBypassServerEnabled()) {
+    return createDesignBypassWeb3Session();
+  }
+
   try {
     const cookieStore = await cookies();
 
@@ -79,29 +128,19 @@ export async function getWeb3SessionFromCookies(): Promise<Web3SessionData | nul
       return null;
     }
 
-    // Parse user data from cookie
-    let userData: UserCookieData | null = null;
-    try {
-      userData = JSON.parse(decodeURIComponent(userCookie)) as UserCookieData;
-    } catch (parseError) {
-      logger.auth.error('Failed to parse user cookie', { parseError: String(parseError) });
+    const userData = parseUserCookieData(userCookie);
+    if (userData === null) {
       return null;
     }
 
     const now = Date.now();
-    const walletAddress = (userData.wallet_address !== undefined && userData.wallet_address !== '')
-      ? userData.wallet_address
-      : (userData.sub ?? '');
-
     const sessionData: Web3SessionData = {
-      walletAddress,
+      walletAddress: getWalletAddress(userData),
       signature: '', // Not accessible (HttpOnly)
-      message: '',   // Not accessible (HttpOnly)
+      message: '', // Not accessible (HttpOnly)
       nonce: '', // Not accessible (HttpOnly)
-      chainId: (process.env['NEXT_PUBLIC_DEFAULT_CHAIN_ID'] !== undefined && process.env['NEXT_PUBLIC_DEFAULT_CHAIN_ID'] !== '')
-        ? parseInt(process.env['NEXT_PUBLIC_DEFAULT_CHAIN_ID'])
-        : 56, // BSC Mainnet - default
-      expiresAt: userData.auth_time !== undefined ? parseInt(userData.auth_time) + 2592000000 : now + 2592000000, // 30 days default
+      chainId: getDefaultChainId(),
+      expiresAt: getSessionExpiry(userData, now),
     };
 
     // Check if session has expired using new expiresAt calculation
@@ -112,9 +151,10 @@ export async function getWeb3SessionFromCookies(): Promise<Web3SessionData | nul
     }
 
     return sessionData;
-
   } catch (_error) {
-    logger.auth.error('Failed to get Web3 session from cookies', { error: String(_error) });
+    logger.auth.error('Failed to get Web3 session from cookies', {
+      error: String(_error),
+    });
     return null;
   }
 }
@@ -123,7 +163,9 @@ export async function getWeb3SessionFromCookies(): Promise<Web3SessionData | nul
  * Validate Web3 authentication with backend
  * @param _sessionData
  */
-export async function validateWeb3Session(_sessionData: Web3SessionData): Promise<Web3AdminUser | null> {
+export async function validateWeb3Session(
+  _sessionData: Web3SessionData
+): Promise<Web3AdminUser | null> {
   try {
     // Note: Since we don't have access to signature and message (HttpOnly),
     // we'll rely on the backend validation through HttpOnly cookies
@@ -139,13 +181,16 @@ export async function validateWeb3Session(_sessionData: Web3SessionData): Promis
     try {
       userData = JSON.parse(decodeURIComponent(userCookie)) as UserCookieData;
     } catch (parseError) {
-      logger.auth.error('Failed to parse user cookie', { parseError: String(parseError) });
+      logger.auth.error('Failed to parse user cookie', {
+        parseError: String(parseError),
+      });
       return null;
     }
 
-    const walletAddress = (userData.wallet_address !== undefined && userData.wallet_address !== '')
-      ? userData.wallet_address
-      : (userData.sub ?? '');
+    const walletAddress =
+      userData.wallet_address !== undefined && userData.wallet_address !== ''
+        ? userData.wallet_address
+        : (userData.sub ?? '');
 
     const web3User: Web3AdminUser = {
       walletAddress,
@@ -154,12 +199,14 @@ export async function validateWeb3Session(_sessionData: Web3SessionData): Promis
       permissions: userData.permissions ?? [],
       groups: userData.groups ?? [],
       isAdmin: userData.isAdmin ?? true, // Assume admin if user cookie exists
-      sessionExpiry: userData.auth_time !== undefined ? parseInt(userData.auth_time) + 2592000000 : Date.now() + 2592000000, // 30 days default
-      lastVerified: Date.now()
+      sessionExpiry:
+        userData.auth_time !== undefined
+          ? parseInt(userData.auth_time) + 2592000000
+          : Date.now() + 2592000000, // 30 days default
+      lastVerified: Date.now(),
     };
 
     return web3User;
-
   } catch (_error) {
     logger.auth.error('Web3 validation error', { error: String(_error) });
     return null;
@@ -170,7 +217,9 @@ export async function validateWeb3Session(_sessionData: Web3SessionData): Promis
  * Set Web3 session data in secure cookies
  * @param sessionData
  */
-export async function setWeb3Session(sessionData: Web3SessionData): Promise<void> {
+export async function setWeb3Session(
+  sessionData: Web3SessionData
+): Promise<void> {
   await setWeb3SessionAction(sessionData);
 }
 
@@ -190,6 +239,10 @@ export async function clearWeb3Session(): Promise<void> {
  * @param user
  */
 export function hasAdminAccess(user: Web3AdminUser | undefined): boolean {
+  if (isDesignBypassEnabled()) {
+    return true;
+  }
+
   // PERMISSION REFACTOR: Client-side checks are now permissive.
   // Backend enforces actual access control.
   return Boolean(user);
@@ -200,10 +253,13 @@ export function hasAdminAccess(user: Web3AdminUser | undefined): boolean {
  * @param permissions
  * @param platform
  */
-export function getPermissionsByPlatform(permissions: string[], platform: string): string[] {
-  return permissions.filter(permission =>
-    permission.startsWith(`${platform}:`) ||
-    permission === 'admin:*:*'
+export function getPermissionsByPlatform(
+  permissions: string[],
+  platform: string
+): string[] {
+  return permissions.filter(
+    permission =>
+      permission.startsWith(`${platform}:`) || permission === 'admin:*:*'
   );
 }
 
@@ -212,7 +268,10 @@ export function getPermissionsByPlatform(permissions: string[], platform: string
  * @param _permissions
  * @param _withinDays
  */
-export function getExpiringPermissions(_permissions: string[], _withinDays = 7): string[] {
+export function getExpiringPermissions(
+  _permissions: string[],
+  _withinDays = 7
+): string[] {
   // PERMISSION REFACTOR: UI display hint for expiring permissions.
   // Real expiry is enforced by the backend.
   return [];
@@ -227,8 +286,26 @@ export function getExpiringPermissions(_permissions: string[], _withinDays = 7):
  * Web3-only authentication using wallet signatures
  */
 export async function getAdminSession(): Promise<AdminSession> {
-  try {
+  if (await isDesignBypassServerEnabled()) {
+    return {
+      isAuthenticated: true,
+      isLoggedIn: true,
+      user: {
+        walletAddress: DESIGN_BYPASS_WALLET,
+        chainId: 56,
+        displayName: 'EPSX Design Mode',
+        permissions: getDesignBypassPermissions('admin'),
+        groups: ['admin'],
+        isAdmin: true,
+        sessionExpiry: Date.now() + 60 * 60 * 1000,
+        lastVerified: Date.now(),
+      },
+      hasAdminAccess: true,
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+  }
 
+  try {
     // Get Web3 session data from cookies
     const sessionData = await getWeb3SessionFromCookies();
 
@@ -238,7 +315,7 @@ export async function getAdminSession(): Promise<AdminSession> {
         isLoggedIn: false,
         user: null,
         hasAdminAccess: false,
-        error: 'No Web3 session found'
+        error: 'No Web3 session found',
       };
     }
 
@@ -252,7 +329,7 @@ export async function getAdminSession(): Promise<AdminSession> {
         isLoggedIn: false,
         user: null,
         hasAdminAccess: false,
-        error: 'Session validation failed'
+        error: 'Session validation failed',
       };
     }
 
@@ -265,7 +342,7 @@ export async function getAdminSession(): Promise<AdminSession> {
         isLoggedIn: true,
         user: web3User,
         hasAdminAccess: false,
-        error: 'Insufficient admin permissions'
+        error: 'Insufficient admin permissions',
       };
     }
 
@@ -274,9 +351,8 @@ export async function getAdminSession(): Promise<AdminSession> {
       isLoggedIn: true,
       user: web3User,
       hasAdminAccess: true,
-      expiresAt: sessionData.expiresAt
+      expiresAt: sessionData.expiresAt,
     };
-
   } catch (_error) {
     logger.auth.error('Session validation error', { error: String(_error) });
     return {
@@ -284,7 +360,8 @@ export async function getAdminSession(): Promise<AdminSession> {
       isLoggedIn: false,
       user: null,
       hasAdminAccess: false,
-      error: _error instanceof Error ? _error.message : 'Session validation failed'
+      error:
+        _error instanceof Error ? _error.message : 'Session validation failed',
     };
   }
 }
@@ -343,7 +420,7 @@ export const Web3AdminAuth = {
   getExpiringPermissions,
 
   // Authentication flows
-  logout
+  logout,
 };
 
 // Backward compatibility export

--- a/apps/admin-frontend/lib/auth/server.ts
+++ b/apps/admin-frontend/lib/auth/server.ts
@@ -6,12 +6,16 @@
 import { logger } from '@/lib/logger';
 import { COOKIES } from '@/shared/auth/cookies';
 import type { EPSXJWTPayload } from '@/shared/auth/jwt';
+import {
+  getDesignBypassAdminPayload,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 
 /**
  * Enhanced auth user type based on our JWT structure
  */
 export interface EnhancedAuthUser extends EPSXJWTPayload {
-  id: string;  // Maps to `sub` field
+  id: string; // Maps to `sub` field
 }
 
 /**
@@ -27,7 +31,9 @@ export interface ServerSession {
  * Convert JWT payload to EnhancedAuthUser
  * @param payload
  */
-export function createEnhancedAuthUser(payload: EPSXJWTPayload): EnhancedAuthUser {
+export function createEnhancedAuthUser(
+  payload: EPSXJWTPayload
+): EnhancedAuthUser {
   return {
     ...payload,
     id: payload.sub,
@@ -38,6 +44,15 @@ export function createEnhancedAuthUser(payload: EPSXJWTPayload): EnhancedAuthUse
  * Server-side auth utilities
  */
 export async function getServerSession(): Promise<ServerSession | null> {
+  if (await isDesignBypassServerEnabled()) {
+    const payload = getDesignBypassAdminPayload();
+    return {
+      user: createEnhancedAuthUser(payload),
+      expires: new Date(payload.exp * 1000).toISOString(),
+      accessToken: 'design-bypass',
+    };
+  }
+
   try {
     const { cookies } = await import('next/headers');
     const { decodeEPSXJWT, isJWTExpired } = await import('@/shared/auth/jwt');
@@ -46,24 +61,32 @@ export async function getServerSession(): Promise<ServerSession | null> {
     // OIDC Migration: Use only OIDC access token
     const jwt = cookieStore.get(COOKIES.access_token)?.value;
 
-    if (jwt === undefined || jwt === '') { return null; }
+    if (jwt === undefined || jwt === '') {
+      return null;
+    }
 
     // Check expiration first
-    if (isJWTExpired(jwt)) { return null; }
+    if (isJWTExpired(jwt)) {
+      return null;
+    }
 
     // Decode payload (skipping signature verification due to RS256/HS256 mismatch)
     const payload = decodeEPSXJWT(jwt);
-    if (!payload) { return null; }
+    if (!payload) {
+      return null;
+    }
 
     // Convert to proper ServerSession type
     const user = createEnhancedAuthUser(payload);
     return {
       user,
-      expires: new Date((payload.exp) * 1000).toISOString(),
+      expires: new Date(payload.exp * 1000).toISOString(),
       accessToken: jwt,
     };
   } catch (_error) {
-    logger.auth.error('Failed to get server session', { error: String(_error) });
+    logger.auth.error('Failed to get server session', {
+      error: String(_error),
+    });
     return null;
   }
 }
@@ -74,7 +97,9 @@ export async function getServerSession(): Promise<ServerSession | null> {
 export async function getCurrentUser(): Promise<EnhancedAuthUser | null> {
   try {
     const session = await getServerSession();
-    if (!session?.user) { return null; }
+    if (!session?.user) {
+      return null;
+    }
 
     return createEnhancedAuthUser(session.user);
   } catch (_error) {
@@ -100,7 +125,9 @@ export async function requireAdminAuth(): Promise<EnhancedAuthUser> {
 export async function getUserContext() {
   try {
     const user = await getCurrentUser();
-    if (user === null) { return null; }
+    if (user === null) {
+      return null;
+    }
 
     const platform = user.platform_context ?? user.primary_platform ?? 'epsx';
 

--- a/apps/admin-frontend/lib/data/access-management.ts
+++ b/apps/admin-frontend/lib/data/access-management.ts
@@ -1,6 +1,6 @@
 /**
  * Server-side data fetching for Access Management
- * 
+ *
  * These functions are designed to be called from Server Components
  * to fetch initial data for the unified access management page.
  */
@@ -87,7 +87,7 @@ const API_ROUTES_LOCAL = {
   },
   WALLETS: {
     STATS: '/api/admin/wallets/stats',
-  }
+  },
 } as const;
 
 // ============================================================================
@@ -100,8 +100,10 @@ const API_ROUTES_LOCAL = {
 export async function fetchWalletStats(): Promise<WalletStats> {
   try {
     const apiClient = createAdminApiClient({ serverSide: true });
-    const response = await apiClient.get<WalletStats>(API_ROUTES_LOCAL.WALLETS.STATS);
-    redirectOnForbidden(response, WALLET_MGMT_ROUTE);
+    const response = await apiClient.get<WalletStats>(
+      API_ROUTES_LOCAL.WALLETS.STATS
+    );
+    await redirectOnForbidden(response, WALLET_MGMT_ROUTE);
 
     if (response.success && response.data) {
       return response.data;
@@ -113,17 +115,19 @@ export async function fetchWalletStats(): Promise<WalletStats> {
       inactive_users: 0,
       new_users_30_days: 0,
       active_users_30_days: 0,
-      growth_rate: 0
+      growth_rate: 0,
     };
   } catch (e) {
-    if (typeof e === 'object' && e !== null && 'digest' in e) { throw e; }
+    if (typeof e === 'object' && e !== null && 'digest' in e) {
+      throw e;
+    }
     return {
       total_users: 0,
       active_users: 0,
       inactive_users: 0,
       new_users_30_days: 0,
       active_users_30_days: 0,
-      growth_rate: 0
+      growth_rate: 0,
     };
   }
 }
@@ -131,7 +135,9 @@ export async function fetchWalletStats(): Promise<WalletStats> {
 /**
  * Helper to extract plans from API response
  */
-function extractPlans(data: PlansApiResponse | null | undefined): PlanResponse[] {
+function extractPlans(
+  data: PlansApiResponse | null | undefined
+): PlanResponse[] {
   if (!data) {
     return [];
   }
@@ -150,7 +156,7 @@ export async function fetchPolicies(): Promise<AccessPolicy[]> {
       plansClient.listPlans({ limit: 100 }),
       apiClient.get<PlansApiResponse>(API_ROUTES_LOCAL.PERMISSIONS.PLANS),
     ]);
-    redirectOnForbidden(groupsRes, WALLET_MGMT_ROUTE);
+    await redirectOnForbidden(groupsRes, WALLET_MGMT_ROUTE);
 
     const policies: AccessPolicy[] = [];
 
@@ -165,15 +171,17 @@ export async function fetchPolicies(): Promise<AccessPolicy[]> {
     // Transform groups to policies (exclude subscription type - handled by plans)
     if (groupsRes.success && groupsRes.data) {
       const rawGroups = groupsRes.data.plans ?? groupsRes.data;
-      const groupsArray = (Array.isArray(rawGroups) ? rawGroups : []) as unknown as GroupData[];
+      const groupsArray = (Array.isArray(rawGroups)
+        ? rawGroups
+        : []) as unknown as GroupData[];
       groupsArray
-        .filter((g) => g.group_type !== 'subscription')
-        .forEach((group) => {
+        .filter(g => g.group_type !== 'subscription')
+        .forEach(group => {
           // Add plan_type if missing (mapping group_type to plan_type for groupToPolicy)
           const planType = group.plan_type ?? group.group_type;
           const normalizedGroup = {
             ...group,
-            plan_type: planType ?? 'manual'
+            plan_type: planType ?? 'manual',
           } as unknown as PermissionPlan;
 
           policies.push(groupToPolicy(normalizedGroup));
@@ -182,7 +190,9 @@ export async function fetchPolicies(): Promise<AccessPolicy[]> {
 
     return policies;
   } catch (e) {
-    if (typeof e === 'object' && e !== null && 'digest' in e) { throw e; }
+    if (typeof e === 'object' && e !== null && 'digest' in e) {
+      throw e;
+    }
     return [];
   }
 }
@@ -197,28 +207,37 @@ function processPlansStats(stats: PolicyStats, plans: PlanResponse[]): void {
   // Calculate MRR
   stats.totalMRR = plans.reduce((sum, plan) => {
     const rawRevenue = plan.revenue_last_30_days;
-    const revenue = typeof rawRevenue === 'string'
-      ? parseFloat(rawRevenue)
-      : (rawRevenue ?? 0);
-    return sum + (isNaN(revenue) ? 0 : (revenue));
+    const revenue =
+      typeof rawRevenue === 'string'
+        ? parseFloat(rawRevenue)
+        : (rawRevenue ?? 0);
+    return sum + (isNaN(revenue) ? 0 : revenue);
   }, 0);
 
   // Count subscribers
-  const planMembers = plans.reduce((sum, p) => sum + (p.subscriber_count ?? 0), 0);
+  const planMembers = plans.reduce(
+    (sum, p) => sum + (p.subscriber_count ?? 0),
+    0
+  );
   stats.totalMembers += planMembers;
 }
 
 /**
  * Process group statistics
  */
-function processGroupsStats(stats: PolicyStats, groupsResData: PlansApiResponse): void {
+function processGroupsStats(
+  stats: PolicyStats,
+  groupsResData: PlansApiResponse
+): void {
   const rawGroups = groupsResData.plans ?? groupsResData;
-  const groupsArray = (Array.isArray(rawGroups) ? rawGroups : []) as unknown as GroupData[];
-  const nonSubGroups = groupsArray.filter((g) => g.group_type !== 'subscription');
-  stats.activeGroups = nonSubGroups.filter((g) => g.is_active === true).length;
+  const groupsArray = (Array.isArray(rawGroups)
+    ? rawGroups
+    : []) as unknown as GroupData[];
+  const nonSubGroups = groupsArray.filter(g => g.group_type !== 'subscription');
+  stats.activeGroups = nonSubGroups.filter(g => g.is_active === true).length;
 
   // Count by type
-  nonSubGroups.forEach((group) => {
+  nonSubGroups.forEach(group => {
     const typeMap: Record<string, PolicyType | undefined> = {
       manual: 'manual',
       web3_asset: 'web3_asset',
@@ -246,7 +265,7 @@ export async function fetchPolicyStats(): Promise<PolicyStats> {
       apiClient.get<PlansApiResponse>(API_ROUTES_LOCAL.PERMISSIONS.PLANS),
       apiClient.get<AnalyticsData>(API_ROUTES_LOCAL.PERMISSIONS.ANALYTICS),
     ]);
-    redirectOnForbidden(groupsRes, WALLET_MGMT_ROUTE);
+    await redirectOnForbidden(groupsRes, WALLET_MGMT_ROUTE);
 
     const stats: PolicyStats = { ...DEFAULT_POLICY_STATS };
 
@@ -269,12 +288,17 @@ export async function fetchPolicyStats(): Promise<PolicyStats> {
     }
 
     // Calculate total policies
-    const total = Object.values(stats.byType).reduce((acc, count) => acc + count, 0);
+    const total = Object.values(stats.byType).reduce(
+      (acc, count) => acc + count,
+      0
+    );
     stats.totalPolicies = total;
 
     return stats;
   } catch (e) {
-    if (typeof e === 'object' && e !== null && 'digest' in e) { throw e; }
+    if (typeof e === 'object' && e !== null && 'digest' in e) {
+      throw e;
+    }
     return DEFAULT_POLICY_STATS;
   }
 }
@@ -282,11 +306,16 @@ export async function fetchPolicyStats(): Promise<PolicyStats> {
 /**
  * Fetch permission definitions count and platform count
  */
-export async function fetchPermissionStats(): Promise<{ count: number; platformCount: number }> {
+export async function fetchPermissionStats(): Promise<{
+  count: number;
+  platformCount: number;
+}> {
   try {
     const apiClient = createAdminApiClient({ serverSide: true });
-    const response = await apiClient.get<PermissionDefinitionDto[]>(API_ROUTES_LOCAL.PERMISSIONS.DEFINITIONS);
-    redirectOnForbidden(response, WALLET_MGMT_ROUTE);
+    const response = await apiClient.get<PermissionDefinitionDto[]>(
+      API_ROUTES_LOCAL.PERMISSIONS.DEFINITIONS
+    );
+    await redirectOnForbidden(response, WALLET_MGMT_ROUTE);
 
     if (response.success && response.data) {
       const definitions = Array.isArray(response.data) ? response.data : [];
@@ -300,7 +329,9 @@ export async function fetchPermissionStats(): Promise<{ count: number; platformC
     return { count: 0, platformCount: 0 };
   } catch (e) {
     // Let Next.js redirect errors propagate
-    if (typeof e === 'object' && e !== null && 'digest' in e) { throw e; }
+    if (typeof e === 'object' && e !== null && 'digest' in e) {
+      throw e;
+    }
     return { count: 0, platformCount: 0 };
   }
 }

--- a/apps/admin-frontend/lib/server/auth.ts
+++ b/apps/admin-frontend/lib/server/auth.ts
@@ -5,7 +5,17 @@
 import { redirect } from 'next/navigation';
 
 import { COOKIES } from '@/shared/auth/cookies';
-import { generateCodeChallenge, generateCodeVerifier, generateRandomString } from '@/shared/auth/pkce';
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateRandomString,
+} from '@/shared/auth/pkce';
+import {
+  getDesignBypassAdminPayload,
+  getDesignBypassPermissions,
+  getDesignBypassUserInfo,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 import { logger } from '@/lib/logger';
 
 import type { User } from '../../types/admin/iam';
@@ -19,7 +29,11 @@ interface TokenResponse {
 }
 
 // OAuth authorization URL generation now handled by shared utilities
-async function getAuthorizationUrl(): Promise<{ url: string; codeVerifier: string; state: string }> {
+async function getAuthorizationUrl(): Promise<{
+  url: string;
+  codeVerifier: string;
+  state: string;
+}> {
   const codeVerifier = generateCodeVerifier();
   // codeChallenge generated but unused in current simplified flow
   await generateCodeChallenge(codeVerifier);
@@ -33,12 +47,24 @@ export type { EPSXJWTPayload };
 /**
  * Get server session with JWT verification
  */
-export async function getServerSession(): Promise<{ isAuthenticated: boolean; user: EPSXJWTPayload | null }> {
+export async function getServerSession(): Promise<{
+  isAuthenticated: boolean;
+  user: EPSXJWTPayload | null;
+}> {
+  if (await isDesignBypassServerEnabled()) {
+    return {
+      isAuthenticated: true,
+      user: getDesignBypassAdminPayload(),
+    };
+  }
+
   try {
     const { getSessionFromJWT } = await import('./token');
-    return await getSessionFromJWT() as { isAuthenticated: boolean; user: EPSXJWTPayload | null };
+    return (await getSessionFromJWT()) as {
+      isAuthenticated: boolean;
+      user: EPSXJWTPayload | null;
+    };
   } catch (error) {
-
     logger.auth.error('Failed to get server session', { error: String(error) });
     return { isAuthenticated: false, user: null };
   }
@@ -48,10 +74,37 @@ export async function getServerSession(): Promise<{ isAuthenticated: boolean; us
  * Get authenticated admin user from JWT cookies
  */
 export async function getAuthUser(): Promise<User | null> {
+  if (await isDesignBypassServerEnabled()) {
+    const userInfo = getDesignBypassUserInfo('admin');
+    return {
+      id: userInfo.wallet_address,
+      email: userInfo.email ?? '',
+      name: 'EPSX Design Mode',
+      displayName: 'EPSX Design Mode',
+      emailVerified: true,
+      disabled: false,
+      roles: ['super_admin'],
+      groups: ['admin'],
+      attachedPolicies: [],
+      status: 'active',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date().toISOString(),
+      permissions: userInfo.permissions,
+      access: userInfo.access,
+      wallet_address: userInfo.wallet_address,
+      is_admin: true,
+      admin_permissions: getDesignBypassPermissions('admin'),
+      role: 'super_admin',
+      sub: userInfo.sub,
+    } as unknown as User;
+  }
+
   try {
     const { verifyJWTFromCookies, getJWTFromCookies } = await import('./token');
     const user = await verifyJWTFromCookies();
-    if (user === null) { return null; }
+    if (user === null) {
+      return null;
+    }
 
     // Include raw JWT for client-side hydration (access_token is HttpOnly,
     // so client JS can't read it from cookies — pass it via initialUser)
@@ -75,9 +128,13 @@ export async function exchangeCodeForTokens(
   code: string,
   codeVerifier: string,
   _state: string
-): Promise<{ accessToken: string; idToken: string; refreshToken: string; expiresIn: number }> {
+): Promise<{
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}> {
   try {
-
     // Use consolidated auth config for consistency
     const { authConfig } = await import('../../config/env');
 
@@ -89,7 +146,7 @@ export async function exchangeCodeForTokens(
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': 'application/json',
+        Accept: 'application/json',
       },
       body: new URLSearchParams({
         grant_type: 'authorization_code',
@@ -98,27 +155,37 @@ export async function exchangeCodeForTokens(
         client_id: clientId,
         code_verifier: codeVerifier,
       }),
-    })
+    });
 
     if (!response.ok) {
-      const errorText = await response.text()
+      const errorText = await response.text();
 
-      logger.auth.error('Token exchange failed', { status: response.status, statusText: response.statusText, body: errorText })
-      throw new Error(`Token exchange failed: ${response.status} ${response.statusText} - ${errorText}`)
+      logger.auth.error('Token exchange failed', {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+      throw new Error(
+        `Token exchange failed: ${response.status} ${response.statusText} - ${errorText}`
+      );
     }
 
-    const tokens = await response.json() as TokenResponse
+    const tokens = (await response.json()) as TokenResponse;
 
     return {
       accessToken: tokens.access_token,
       idToken: tokens.id_token,
       refreshToken: tokens.refresh_token,
       expiresIn: tokens.expires_in ?? 3600, // Include expiry information
-    }
+    };
   } catch (error) {
-
-    logger.auth.error('Token exchange error', { error: error instanceof Error ? error.message : String(error) })
-    throw new Error(`Failed to exchange authorization code for tokens: ${error instanceof Error ? error.message : 'Unknown error'}`, { cause: error })
+    logger.auth.error('Token exchange error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new Error(
+      `Failed to exchange authorization code for tokens: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      { cause: error }
+    );
   }
 }
 
@@ -133,7 +200,7 @@ export async function getUserInfo(accessToken: string): Promise<unknown> {
 
   const response = await fetch(`${apiUrl}/oauth/userinfo`, {
     headers: {
-      'Authorization': `Bearer ${accessToken}`,
+      Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',
     },
   });
@@ -141,8 +208,14 @@ export async function getUserInfo(accessToken: string): Promise<unknown> {
   if (!response.ok) {
     const errorText = await response.text();
 
-    logger.auth.error('UserInfo fetch failed', { status: response.status, statusText: response.statusText, body: errorText });
-    throw new Error(`UserInfo fetch failed: ${response.status} ${response.statusText} - ${errorText}`);
+    logger.auth.error('UserInfo fetch failed', {
+      status: response.status,
+      statusText: response.statusText,
+      body: errorText,
+    });
+    throw new Error(
+      `UserInfo fetch failed: ${response.status} ${response.statusText} - ${errorText}`
+    );
   }
 
   return await response.json();
@@ -152,7 +225,9 @@ export async function getUserInfo(accessToken: string): Promise<unknown> {
  * Redirect to backend Chef Kitchen login with proper PKCE parameters
  * @param callbackUrl
  */
-export async function redirectToBackendAdminLogin(callbackUrl?: string): Promise<never> {
+export async function redirectToBackendAdminLogin(
+  callbackUrl?: string
+): Promise<never> {
   try {
     // Generate proper PKCE parameters
     const { url, codeVerifier, state } = await getAuthorizationUrl();
@@ -167,15 +242,15 @@ export async function redirectToBackendAdminLogin(callbackUrl?: string): Promise
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: 600, // 10 minutes
-      path: '/'
+      path: '/',
     });
 
     cookieStore.set('oauth_state', state, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
-      maxAge: 600, // 10 minutes  
-      path: '/'
+      maxAge: 600, // 10 minutes
+      path: '/',
     });
 
     // Store callback URL for after authentication
@@ -185,7 +260,7 @@ export async function redirectToBackendAdminLogin(callbackUrl?: string): Promise
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'lax',
         maxAge: 600, // 10 minutes
-        path: '/'
+        path: '/',
       });
     }
 
@@ -195,16 +270,27 @@ export async function redirectToBackendAdminLogin(callbackUrl?: string): Promise
       throw error;
     }
 
-    logger.auth.error('Failed to setup PKCE redirect', { error: String(error) });
+    logger.auth.error('Failed to setup PKCE redirect', {
+      error: String(error),
+    });
     // Fallback to simple redirect without PKCE using consolidated config
     const { authConfig } = await import('../../config/env');
     const backendAdminLoginUrl = new URL('/oauth/authorize', authConfig.apiUrl);
     backendAdminLoginUrl.searchParams.set('client_id', authConfig.clientId);
-    backendAdminLoginUrl.searchParams.set('redirect_uri', authConfig.callbackUrl);
-    backendAdminLoginUrl.searchParams.set('scope', 'openid profile email permissions');
+    backendAdminLoginUrl.searchParams.set(
+      'redirect_uri',
+      authConfig.callbackUrl
+    );
+    backendAdminLoginUrl.searchParams.set(
+      'scope',
+      'openid profile email permissions'
+    );
     backendAdminLoginUrl.searchParams.set('response_type', 'code');
     if (callbackUrl !== undefined && callbackUrl !== '') {
-      backendAdminLoginUrl.searchParams.set('state', encodeURIComponent(callbackUrl));
+      backendAdminLoginUrl.searchParams.set(
+        'state',
+        encodeURIComponent(callbackUrl)
+      );
     }
     redirect(backendAdminLoginUrl.toString());
   }
@@ -219,6 +305,10 @@ export async function redirectToBackendAdminLogin(callbackUrl?: string): Promise
  * @param redirectPath
  */
 export async function requireAuth(redirectPath?: string): Promise<unknown> {
+  if (await isDesignBypassServerEnabled()) {
+    return getAuthUser();
+  }
+
   const user = await getAuthUser();
 
   if (user === null) {
@@ -246,9 +336,7 @@ export async function clearSession(): Promise<void> {
     // Also clear legacy cookie for migration compatibility
     cookieStore.delete('epsx_admin_jwt');
   } catch (error) {
-
     logger.auth.error('Failed to clear session', { error: String(error) });
     throw error;
   }
 }
-

--- a/apps/admin-frontend/middleware.ts
+++ b/apps/admin-frontend/middleware.ts
@@ -1,76 +1,186 @@
 import { COOKIES, getServerAuthToken } from '@/shared/auth/cookies';
+import {
+  DESIGN_BYPASS_COOKIE,
+  DESIGN_BYPASS_HEADER,
+  DESIGN_BYPASS_QUERY_PARAM,
+  isDesignBypassRequestEnabled,
+  isDesignBypassTruthy,
+} from '@/shared/utils/design-bypass';
 import { getBackendUrl } from '@/shared/utils/url-resolver';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 const PUBLIC_ROUTES = [
-    '/login',
-    '/auth',
-    '/api/auth',
-    '/api/public',
-    '/unauthorized',
-    '/access-denied',
-    '/_next',
-    '/favicon.ico',
-    '/robots.txt',
-    '/sitemap.xml',
-    '/manifest.json',
-    '/screenshots',
+  '/login',
+  '/auth',
+  '/api/auth',
+  '/api/public',
+  '/unauthorized',
+  '/access-denied',
+  '/_next',
+  '/favicon.ico',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/manifest.json',
+  '/screenshots',
 ];
 
 const LOGIN_PATH = '/auth';
 const BACKEND_URL = getBackendUrl('server');
+const AUTH_COOKIE_NAMES = [
+  COOKIES.access_token,
+  COOKIES.refresh_token,
+  COOKIES.id_token,
+  COOKIES.user,
+  COOKIES.sid,
+  COOKIES.auth_time,
+  COOKIES.expires_at,
+];
 
 function isPublicRoute(pathname: string): boolean {
-    return PUBLIC_ROUTES.some(route => pathname.startsWith(route));
+  return PUBLIC_ROUTES.some(route => pathname.startsWith(route));
 }
 
-function handleLoginRoute(request: NextRequest, hasToken: boolean): NextResponse | null {
-    if (request.nextUrl.pathname !== LOGIN_PATH) {
-        return null;
+function clearAuthCookies(response: NextResponse): NextResponse {
+  const isProd = process.env.NODE_ENV === 'production';
+
+  AUTH_COOKIE_NAMES.forEach(name => {
+    response.cookies.set(name, '', {
+      maxAge: 0,
+      secure: isProd,
+      sameSite: 'lax',
+      path: '/',
+    });
+  });
+
+  return response;
+}
+
+function createNextResponse(requestHeaders?: Headers): NextResponse {
+  if (requestHeaders === undefined) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+function handleDesignBypass(
+  request: NextRequest,
+  requestHeaders: Headers,
+  bypassEnabled: boolean
+): NextResponse | null {
+  if (!request.nextUrl.searchParams.has(DESIGN_BYPASS_QUERY_PARAM)) {
+    if (!bypassEnabled) {
+      return null;
     }
 
-    // Clear expired session cookies and redirect to gate
-    const params = request.nextUrl.searchParams;
-    if (params.get('reason') === 'no-session' || params.has('clear')) {
-        const resp = NextResponse.redirect(new URL('/', request.url));
-        const isProd = process.env.NODE_ENV === 'production';
-        [COOKIES.access_token, COOKIES.refresh_token, COOKIES.id_token,
-         COOKIES.user, COOKIES.sid, COOKIES.auth_time, COOKIES.expires_at].forEach(name => {
-            resp.cookies.set(name, '', { maxAge: 0, secure: isProd, sameSite: 'lax', path: '/' });
-        });
-        return resp;
-    }
+    const response = createNextResponse(requestHeaders);
+    response.headers.set(DESIGN_BYPASS_HEADER, '1');
+    return response;
+  }
 
-    // No token: pass through — page.tsx redirects to / which shows gate
-    if (!hasToken) {
-        return NextResponse.next();
-    }
+  const raw = request.nextUrl.searchParams.get(DESIGN_BYPASS_QUERY_PARAM);
+  const response = createNextResponse(requestHeaders);
+  const shouldEnableBypass = isDesignBypassTruthy(raw);
 
-    // Has token: redirect authenticated users away from /auth
-    return NextResponse.redirect(new URL('/', request.url));
+  response.cookies.set(DESIGN_BYPASS_COOKIE, shouldEnableBypass ? '1' : '', {
+    httpOnly: true,
+    secure: DESIGN_BYPASS_COOKIE.startsWith('__Host-'),
+    sameSite: 'lax',
+    path: '/',
+    maxAge: shouldEnableBypass ? 60 * 60 : 0,
+  });
+
+  if (bypassEnabled) {
+    response.headers.set(DESIGN_BYPASS_HEADER, '1');
+  }
+
+  return response;
+}
+
+function handleLoginRoute(
+  request: NextRequest,
+  hasToken: boolean
+): NextResponse | null {
+  if (request.nextUrl.pathname !== LOGIN_PATH) {
+    return null;
+  }
+
+  // Clear expired session cookies and redirect to gate
+  const params = request.nextUrl.searchParams;
+  if (params.get('reason') === 'no-session' || params.has('clear')) {
+    return clearAuthCookies(NextResponse.redirect(new URL('/', request.url)));
+  }
+
+  // No token: pass through — page.tsx redirects to / which shows gate
+  if (!hasToken) {
+    return NextResponse.next();
+  }
+
+  // Has token: redirect authenticated users away from /auth
+  return NextResponse.redirect(new URL('/', request.url));
 }
 
 async function extractErrorDetail(res: Response): Promise<string> {
-    try {
-        const text = await res.text();
-        if (!text) {
-            return '';
-        }
-        const data = JSON.parse(text) as Record<string, unknown>;
-        if ('message' in data && typeof data.message === 'string') {
-            return `&detail=${encodeURIComponent(data.message)}`;
-        }
-        if ('error' in data && typeof data.error === 'object' && data.error !== null) {
-            const errObj = data.error as Record<string, unknown>;
-            if ('message' in errObj && typeof errObj.message === 'string') {
-                return `&detail=${encodeURIComponent(errObj.message)}`;
-            }
-        }
-    } catch (_e) {
-        // Ignore parse errors
+  try {
+    const text = await res.text();
+    if (!text) {
+      return '';
     }
-    return '';
+    const data = JSON.parse(text) as Record<string, unknown>;
+    if ('message' in data && typeof data.message === 'string') {
+      return `&detail=${encodeURIComponent(data.message)}`;
+    }
+    if (
+      'error' in data &&
+      typeof data.error === 'object' &&
+      data.error !== null
+    ) {
+      const errObj = data.error as Record<string, unknown>;
+      if ('message' in errObj && typeof errObj.message === 'string') {
+        return `&detail=${encodeURIComponent(errObj.message)}`;
+      }
+    }
+  } catch (_e) {
+    // Ignore parse errors
+  }
+  return '';
+}
+
+async function verifyAdminAccess(
+  request: NextRequest,
+  token: string
+): Promise<NextResponse | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/admin/me`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (res.ok) {
+      return null;
+    }
+
+    if (res.status === 401) {
+      return clearAuthCookies(NextResponse.redirect(new URL('/auth', request.url)));
+    }
+
+    const detail = await extractErrorDetail(res);
+    const reason =
+      res.status === 403 ? 'insufficient_permissions' : 'backend_error';
+    return NextResponse.redirect(
+      new URL(`/access-denied?reason=${reason}${detail}`, request.url)
+    );
+  } catch {
+    return NextResponse.redirect(
+      new URL('/access-denied?reason=backend_unavailable', request.url)
+    );
+  }
 }
 
 /**
@@ -78,79 +188,61 @@ async function extractErrorDetail(res: Response): Promise<string> {
  * Verifies admin permissions by probing the backend; no JWT decoding in frontend.
  */
 export async function middleware(request: NextRequest) {
-    const { pathname } = request.nextUrl;
+  const { pathname } = request.nextUrl;
 
-    // Logout via middleware — clears __Host- cookies at HTTP level
-    if (request.nextUrl.searchParams.has('logout')) {
-        const cleanUrl = new URL(pathname, request.url);
-        const resp = NextResponse.redirect(cleanUrl);
-        const isProd = process.env.NODE_ENV === 'production';
-        [COOKIES.access_token, COOKIES.refresh_token, COOKIES.id_token,
-         COOKIES.user, COOKIES.sid, COOKIES.auth_time, COOKIES.expires_at].forEach(name => {
-            resp.cookies.set(name, '', { maxAge: 0, secure: isProd, sameSite: 'lax', path: '/' });
-        });
-        return resp;
-    }
+  const bypassEnabled = isDesignBypassRequestEnabled(
+    request.nextUrl.searchParams,
+    request.cookies.get(DESIGN_BYPASS_COOKIE)?.value
+  );
 
-    const token = getServerAuthToken(request.cookies);
-    const hasToken = token !== null;
+  const requestHeaders = new Headers(request.headers);
+  if (bypassEnabled) {
+    requestHeaders.set(DESIGN_BYPASS_HEADER, '1');
+  }
 
-    // Handle /auth (LOGIN_PATH) before public route check so authenticated users are redirected
-    const loginResp = handleLoginRoute(request, hasToken);
-    if (loginResp !== null) {
-        return loginResp;
-    }
+  const bypassResponse = handleDesignBypass(
+    request,
+    requestHeaders,
+    bypassEnabled
+  );
+  if (bypassResponse !== null) {
+    return bypassResponse;
+  }
 
-    if (isPublicRoute(pathname)) {
-        return NextResponse.next();
-    }
+  // Logout via middleware — clears __Host- cookies at HTTP level
+  if (request.nextUrl.searchParams.has('logout')) {
+    const cleanUrl = new URL(pathname, request.url);
+    return clearAuthCookies(NextResponse.redirect(cleanUrl));
+  }
 
-    // No token: pass through — layout gate shows auth modal inline
-    if (!hasToken) {
-        return NextResponse.next();
-    }
+  const token = getServerAuthToken(request.cookies);
+  const hasToken = token !== null;
 
-    // Verify admin permission by calling the backend — backend is the sole authority
-    // Fail-closed approach: any non-2xx response rejects access
-    try {
-        const res = await fetch(`${BACKEND_URL}/api/admin/me`, {
-            method: 'GET',
-            headers: { Authorization: `Bearer ${token}` },
-            signal: AbortSignal.timeout(5000),
-        });
+  // Handle /auth (LOGIN_PATH) before public route check so authenticated users are redirected
+  const loginResp = handleLoginRoute(request, hasToken);
+  if (loginResp !== null) {
+    return loginResp;
+  }
 
-        if (!res.ok) {
-            // 401 = token expired → clear all auth cookies and force fresh login
-            if (res.status === 401) {
-                const resp = NextResponse.redirect(new URL('/auth', request.url));
-                const isProd = process.env.NODE_ENV === 'production';
-                const authCookies = [
-                    COOKIES.access_token, COOKIES.refresh_token, COOKIES.id_token,
-                    COOKIES.user, COOKIES.sid, COOKIES.auth_time, COOKIES.expires_at,
-                ];
-                authCookies.forEach(name => {
-                    resp.cookies.set(name, '', { maxAge: 0, secure: isProd, sameSite: 'lax', path: '/' });
-                });
-                return resp;
-            }
-
-            const detail = await extractErrorDetail(res);
-            const reason = res.status === 403 ? 'insufficient_permissions' : 'backend_error';
-            return NextResponse.redirect(
-                new URL(`/access-denied?reason=${reason}${detail}`, request.url)
-            );
-        }
-    } catch {
-        return NextResponse.redirect(
-            new URL('/access-denied?reason=backend_unavailable', request.url)
-        );
-    }
-
+  if (isPublicRoute(pathname)) {
     return NextResponse.next();
+  }
+
+  // No token: pass through — layout gate shows auth modal inline
+  if (!hasToken) {
+    return NextResponse.next();
+  }
+
+  // Verify admin permission by calling the backend — backend is the sole authority
+  // Fail-closed approach: any non-2xx response rejects access
+  const verifyResponse = await verifyAdminAccess(request, token);
+  if (verifyResponse !== null) {
+    return verifyResponse;
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {
-    matcher: [
-        '/((?!_next/static|_next/image|favicon.ico|api/health).*)',
-    ],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|api/health).*)'],
 };

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -8,12 +8,19 @@ import { SharedOpenIDWeb3Provider } from '@/shared/components/auth';
 import type { UserInfoResponse } from '@/shared/auth/client';
 import { COOKIES } from '@/shared/auth/cookies';
 import { getServerConfig } from '@/shared/config/wagmi';
+import {
+  getDesignBypassUserInfo,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 import { initializeRuntimeEnvironment } from '@/shared/utils/runtime-env-validator';
 import { Kanit } from 'next/font/google';
 import { cookies, headers } from 'next/headers';
 import { Toaster } from 'sonner';
 import { cookieToInitialState } from 'wagmi';
-import { ChatWidget, FrontendAuthModal } from '@/components/layout/lazy-widgets';
+import {
+  ChatWidget,
+  FrontendAuthModal,
+} from '@/components/layout/lazy-widgets';
 import './globals.css';
 
 // Initialize runtime environment validation
@@ -73,10 +80,15 @@ export default async function RootLayout({
     const cookieStore = await cookies();
     const userCookie = cookieStore.get(COOKIES.user)?.value;
     if (userCookie !== undefined && userCookie !== '') {
-      initialUser = JSON.parse(decodeURIComponent(userCookie)) as UserInfoResponse;
+      initialUser = JSON.parse(
+        decodeURIComponent(userCookie)
+      ) as UserInfoResponse;
       // Include HttpOnly access_token for client-side hydration
       // (JS can't read HttpOnly cookies, so pass it via initialUser)
-      if (initialUser !== null && (initialUser.access === undefined || initialUser.access === '')) {
+      if (
+        initialUser !== null &&
+        (initialUser.access === undefined || initialUser.access === '')
+      ) {
         const accessToken = cookieStore.get(COOKIES.access_token)?.value;
         if (accessToken !== undefined && accessToken !== '') {
           initialUser = { ...initialUser, access: accessToken };
@@ -85,6 +97,10 @@ export default async function RootLayout({
     }
   } catch {
     // Invalid cookie - start fresh
+  }
+
+  if (initialUser === null && (await isDesignBypassServerEnabled())) {
+    initialUser = getDesignBypassUserInfo('frontend');
   }
 
   // Unified Web3 Cookie Hydration
@@ -99,7 +115,10 @@ export default async function RootLayout({
     // Cookie value might be URL-encoded (e.g., '%7B%22stat...' instead of raw JSON)
     // Try decoding the cookie string first
     try {
-      const decodedCookie = cookie !== null && cookie !== undefined ? decodeURIComponent(cookie) : null;
+      const decodedCookie =
+        cookie !== null && cookie !== undefined
+          ? decodeURIComponent(cookie)
+          : null;
       initialState = cookieToInitialState(getServerConfig(), decodedCookie);
     } catch {
       // If all parsing fails, use undefined (fresh state)
@@ -111,7 +130,10 @@ export default async function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         {/* CSP via meta tag — Cloudflare edge overwrites the HTTP header */}
-        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; script-src-elem 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://*.epsx.io wss://*.epsx.io https://static.cloudflareinsights.com https://*.walletconnect.com wss://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.org https://*.bnbchain.org https://*.web3modal.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'" />
+        <meta
+          httpEquiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; script-src-elem 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://*.epsx.io wss://*.epsx.io https://static.cloudflareinsights.com https://*.walletconnect.com wss://*.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.org https://*.bnbchain.org https://*.web3modal.org; frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org; object-src 'none'; base-uri 'self'; form-action 'self'"
+        />
 
         {/* Mobile performance optimizations */}
         <meta name="msapplication-tap-highlight" content="no" />
@@ -130,14 +152,20 @@ export default async function RootLayout({
           <ClientProviders initialState={initialState}>
             <SharedOpenIDWeb3Provider
               clientId="epsx-frontend"
-              backendUrl={process.env['NEXT_PUBLIC_BACKEND_URL'] || process.env['BACKEND_URL'] || undefined}
+              backendUrl={
+                process.env['NEXT_PUBLIC_BACKEND_URL'] ||
+                process.env['BACKEND_URL'] ||
+                undefined
+              }
               initialUser={initialUser}
             >
               {/* Mobile navigation optimized for touch */}
               <NavigationClient />
 
               {/* Main content with mobile scroll optimization */}
-              <main className="relative min-h-[calc(100svh-3.5rem)]">{children}</main>
+              <main className="relative min-h-[calc(100svh-3.5rem)]">
+                {children}
+              </main>
 
               {/* Sign in modal (triggered by openSignInModal) */}
               <FrontendAuthModal />
@@ -158,7 +186,6 @@ export default async function RootLayout({
                   },
                 }}
               />
-
             </SharedOpenIDWeb3Provider>
           </ClientProviders>
         </GlobalErrorBoundary>

--- a/apps/frontend/lib/server/user-actions.ts
+++ b/apps/frontend/lib/server/user-actions.ts
@@ -1,10 +1,18 @@
 'use server';
 import { cookies } from 'next/headers';
 
-import { COOKIES, COOKIE_OPTIONS, getServerAuthToken } from '@/shared/auth/cookies';
+import {
+  COOKIES,
+  COOKIE_OPTIONS,
+  getServerAuthToken,
+} from '@/shared/auth/cookies';
 
 import { getExplorerTxLink } from '@/shared/config/constants';
 import { createFrontendApiClient } from '@/shared/utils/api-client';
+import {
+  getDesignBypassUserInfo,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 import { getBackendUrl } from '@/shared/utils/url-resolver';
 
 export interface AuthUser {
@@ -50,7 +58,9 @@ async function tryRefresh(
 ): Promise<string | null> {
   try {
     const refreshToken = cookieStore.get(COOKIES.refresh_token)?.value;
-    if (refreshToken === undefined || refreshToken === '') {return null;}
+    if (refreshToken === undefined || refreshToken === '') {
+      return null;
+    }
 
     const backendUrl = getBackendUrl('server');
     const clientId = process.env.NEXT_PUBLIC_OAUTH_CLIENT_ID ?? 'epsx-frontend';
@@ -58,11 +68,16 @@ async function tryRefresh(
     const res = await fetch(`${backendUrl}/api/auth/session/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refresh_token: refreshToken, client_id: clientId }),
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+        client_id: clientId,
+      }),
       cache: 'no-store',
     });
 
-    if (!res.ok) {return null;}
+    if (!res.ok) {
+      return null;
+    }
 
     const data = (await res.json()) as {
       access_token?: string;
@@ -71,7 +86,9 @@ async function tryRefresh(
       user?: Record<string, unknown>;
     };
     const newToken = data.access_token;
-    if (typeof newToken !== 'string' || newToken === '') {return null;}
+    if (typeof newToken !== 'string' || newToken === '') {
+      return null;
+    }
 
     // Try to persist refreshed cookies (works in server actions, silently fails in SSR)
     try {
@@ -88,15 +105,22 @@ async function tryRefresh(
       // Update user cookie with fresh access token
       const userCookie = cookieStore.get(COOKIES.user)?.value;
       if (userCookie !== undefined && userCookie !== '') {
-        const existing = JSON.parse(decodeURIComponent(userCookie)) as Record<string, unknown>;
+        const existing = JSON.parse(decodeURIComponent(userCookie)) as Record<
+          string,
+          unknown
+        >;
         existing.access = newToken;
-        if (data.user) {Object.assign(existing, data.user);}
+        if (data.user) {
+          Object.assign(existing, data.user);
+        }
         cookieStore.set(COOKIES.user, JSON.stringify(existing), {
           ...COOKIE_OPTIONS.clientSide,
           maxAge: COOKIE_OPTIONS.maxAge.user,
         });
       }
-      const expiresAt = Date.now() + ((data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token) * 1000);
+      const expiresAt =
+        Date.now() +
+        (data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token) * 1000;
       cookieStore.set(COOKIES.expires_at, expiresAt.toString(), {
         ...COOKIE_OPTIONS.clientSide,
         maxAge: COOKIE_OPTIONS.maxAge.expires_at,
@@ -117,7 +141,9 @@ async function tryRefresh(
 async function getValidToken(): Promise<string | null> {
   const cookieStore = await cookies();
   const token = getServerAuthToken(cookieStore);
-  if (token !== null) {return token;}
+  if (token !== null) {
+    return token;
+  }
   return tryRefresh(cookieStore);
 }
 
@@ -139,16 +165,34 @@ function mapPaymentToTransaction(payment: Record<string, unknown>) {
     actualAmount: getNumberValue(payment.amount),
     currency: getStringValue(payment.currency, 'USD'),
     status: getStringValue(payment.status, 'pending'),
-    finishTime: getStringValue(payment.completed_at) || getStringValue(payment.created_at) || new Date().toISOString(),
+    finishTime:
+      getStringValue(payment.completed_at) ||
+      getStringValue(payment.created_at) ||
+      new Date().toISOString(),
     blockchainData: {
-      txHash,  // Backend returns 'tx_hash' not 'transaction_hash'
-      network: 'BSC'
+      txHash, // Backend returns 'tx_hash' not 'transaction_hash'
+      network: 'BSC',
     },
-    blockExplorerUrl: txHash !== '' ? getExplorerTxLink(txHash) : ''
+    blockExplorerUrl: txHash !== '' ? getExplorerTxLink(txHash) : '',
   };
 }
 
 export async function getCurrentUser(): Promise<AuthUser | null> {
+  if (await isDesignBypassServerEnabled()) {
+    const designUser = getDesignBypassUserInfo('frontend');
+    return {
+      id: designUser.wallet_address,
+      wallet_address: designUser.wallet_address,
+      walletAddress: designUser.wallet_address,
+      email: designUser.email,
+      emailVerified: true,
+      permissions: designUser.permissions,
+      role: 'user',
+      package_tier: designUser.packageTier ?? designUser.tier_level,
+      name: 'EPSX Design Mode',
+    };
+  }
+
   try {
     const cookieStore = await cookies();
     let token = getServerAuthToken(cookieStore);
@@ -156,13 +200,17 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
     if (token === null) {
       // No token in any cookie - try refresh_token
       token = await tryRefresh(cookieStore);
-      if (token === null) {return null;}
+      if (token === null) {
+        return null;
+      }
     }
 
     // Validate session with current token
     const client = createFrontendApiClient({ token, serverSide: true });
     const response = await client.get<SessionData>(
-      '/api/auth/web3/session', undefined, { cache: 'no-store' }
+      '/api/auth/web3/session',
+      undefined,
+      { cache: 'no-store' }
     );
 
     if (response.success && response.data?.authenticated) {
@@ -171,11 +219,18 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
 
     // Token expired/invalid - attempt refresh
     const freshToken = await tryRefresh(cookieStore);
-    if (freshToken === null) {return null;}
+    if (freshToken === null) {
+      return null;
+    }
 
-    const freshClient = createFrontendApiClient({ token: freshToken, serverSide: true });
+    const freshClient = createFrontendApiClient({
+      token: freshToken,
+      serverSide: true,
+    });
     const retry = await freshClient.get<SessionData>(
-      '/api/auth/web3/session', undefined, { cache: 'no-store' }
+      '/api/auth/web3/session',
+      undefined,
+      { cache: 'no-store' }
     );
 
     if (retry.success && retry.data?.authenticated) {
@@ -191,13 +246,19 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
 export async function getPaymentHistory() {
   try {
     const token = await getValidToken();
-    if (token === null) {return [];}
+    if (token === null) {
+      return [];
+    }
 
     const client = createFrontendApiClient({ token, serverSide: true });
 
-    const response = await client.get<{ payments: Record<string, unknown>[] }>('/api/payments/history', undefined, {
-      cache: 'no-store'
-    });
+    const response = await client.get<{ payments: Record<string, unknown>[] }>(
+      '/api/payments/history',
+      undefined,
+      {
+        cache: 'no-store',
+      }
+    );
 
     if (!response.success || !response.data) {
       return [];
@@ -212,10 +273,22 @@ export async function getPaymentHistory() {
 }
 
 export async function checkFeatureAccess(feature: string) {
+  if (await isDesignBypassServerEnabled()) {
+    return {
+      hasAccess: true,
+      reason: `Design bypass enabled for ${feature}`,
+      limits: undefined,
+    };
+  }
+
   try {
     const token = await getValidToken();
     if (token === null) {
-      return { hasAccess: false, reason: 'Not authenticated', limits: undefined };
+      return {
+        hasAccess: false,
+        reason: 'Not authenticated',
+        limits: undefined,
+      };
     }
 
     const client = createFrontendApiClient({ token, serverSide: true });
@@ -224,37 +297,60 @@ export async function checkFeatureAccess(feature: string) {
       has_permission: boolean;
       reason?: string;
       limits?: { daily?: number; monthly?: number };
-    }>(`/api/permissions/check?permission=${encodeURIComponent(feature)}`, undefined, {
-      cache: 'no-store'
-    });
+    }>(
+      `/api/permissions/check?permission=${encodeURIComponent(feature)}`,
+      undefined,
+      {
+        cache: 'no-store',
+      }
+    );
 
     if (!response.success || !response.data) {
       return {
         hasAccess: false,
         reason: response.error ?? 'Permission check failed',
-        limits: undefined
+        limits: undefined,
       };
     }
 
     return {
       hasAccess: response.data.has_permission,
-      reason: response.data.reason ?? (response.data.has_permission ? 'Access granted' : 'Access denied'),
-      limits: response.data.limits
+      reason:
+        response.data.reason ??
+        (response.data.has_permission ? 'Access granted' : 'Access denied'),
+      limits: response.data.limits,
     };
   } catch (_error) {
     return {
       hasAccess: false,
       reason: 'Error checking permissions',
-      limits: undefined
+      limits: undefined,
     };
   }
 }
 
 export async function getPaymentStatus(paymentId?: string) {
+  if (await isDesignBypassServerEnabled()) {
+    return {
+      status: 'active',
+      activeSubscription: {
+        id: 'design-bypass-subscription',
+        plan_name: 'Enterprise',
+        package_tier: 'enterprise',
+        status: 'active',
+      },
+      paymentHistory: [],
+    };
+  }
+
   try {
     const token = await getValidToken();
     if (token === null) {
-      return { status: 'unauthenticated', activeSubscription: null, paymentHistory: [] };
+      return {
+        status: 'unauthenticated',
+        activeSubscription: null,
+        paymentHistory: [],
+      };
     }
 
     const client = createFrontendApiClient({ token, serverSide: true });
@@ -269,9 +365,11 @@ export async function getPaymentStatus(paymentId?: string) {
       }>;
     }>('/api/subscriptions/my', undefined, { cache: 'no-store' });
 
-    const activeSubscription = subResponse.success && subResponse.data?.subscriptions
-      ? subResponse.data.subscriptions.find(s => s.status === 'active') ?? null
-      : null;
+    const activeSubscription =
+      subResponse.success && subResponse.data?.subscriptions
+        ? (subResponse.data.subscriptions.find(s => s.status === 'active') ??
+          null)
+        : null;
 
     // Get specific payment if ID provided
     if (paymentId !== undefined) {
@@ -284,20 +382,20 @@ export async function getPaymentStatus(paymentId?: string) {
       return {
         status: typeof paymentStatus === 'string' ? paymentStatus : 'unknown',
         activeSubscription,
-        paymentHistory: []
+        paymentHistory: [],
       };
     }
 
     return {
       status: activeSubscription ? 'subscribed' : 'none',
       activeSubscription,
-      paymentHistory: []
+      paymentHistory: [],
     };
   } catch (_error) {
     return {
       status: 'error',
       activeSubscription: null,
-      paymentHistory: []
+      paymentHistory: [],
     };
   }
 }
@@ -310,7 +408,9 @@ export async function getDebugSessionInfo() {
 
     const clientSession = cookieStore.get(COOKIES.sid)?.value;
     const accessCookie = cookieStore.get(COOKIES.access_token)?.value;
-    const allCookies = cookieStore.getAll().map(c => `${c.name} (${c.value.length} chars)`);
+    const allCookies = cookieStore
+      .getAll()
+      .map(c => `${c.name} (${c.value.length} chars)`);
     const rawHeader = headerStore.get('cookie');
 
     const hasClientSession = clientSession !== undefined;
@@ -321,11 +421,15 @@ export async function getDebugSessionInfo() {
       foundClientSession: hasClientSession,
       foundAccessCookie: hasAccessCookie,
       clientSessionLength: hasClientSession ? clientSession.length : 0,
-      clientSessionPreview: hasClientSession ? `${clientSession.slice(0, 10)  }...` : 'none',
+      clientSessionPreview: hasClientSession
+        ? `${clientSession.slice(0, 10)}...`
+        : 'none',
       accessCookieLength: hasAccessCookie ? accessCookie.length : 0,
       backendUrl: getBackendUrl('server'),
       allCookieNames: allCookies,
-      rawCookieHeader: hasRawHeader ? (`${rawHeader.slice(0, 50)  }...`) : 'missing'
+      rawCookieHeader: hasRawHeader
+        ? `${rawHeader.slice(0, 50)}...`
+        : 'missing',
     };
   } catch (e) {
     return { error: 'Failed to get debug info', details: String(e) };

--- a/apps/frontend/lib/session/index.ts
+++ b/apps/frontend/lib/session/index.ts
@@ -1,6 +1,10 @@
 import { cookies } from 'next/headers';
 import { type User } from '@/shared/types/auth';
 import { getBackendUrl } from '@/shared/utils/url-resolver';
+import {
+  getDesignBypassFrontendUser,
+  isDesignBypassServerEnabled,
+} from '@/shared/utils/design-bypass';
 import { COOKIES } from '@/shared/auth/cookies';
 
 export interface SessionData {
@@ -14,6 +18,14 @@ export interface SessionData {
  */
 export async function getServerSession(): Promise<SessionData | null> {
   try {
+    if (await isDesignBypassServerEnabled()) {
+      return {
+        isAuthenticated: true,
+        user: getDesignBypassFrontendUser(),
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      };
+    }
+
     const cookieStore = await cookies();
     const accessToken = cookieStore.get(COOKIES.access_token)?.value;
 
@@ -25,7 +37,7 @@ export async function getServerSession(): Promise<SessionData | null> {
     const response = await fetch(`${getBackendUrl()}/api/auth/session`, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       },
       cache: 'no-store',
@@ -35,14 +47,16 @@ export async function getServerSession(): Promise<SessionData | null> {
       return { isAuthenticated: false };
     }
 
-    const sessionData = await response.json() as { user?: User; expiresAt?: number };
+    const sessionData = (await response.json()) as {
+      user?: User;
+      expiresAt?: number;
+    };
 
     return {
       isAuthenticated: true,
       user: sessionData.user,
       expiresAt: sessionData.expiresAt,
     };
-
   } catch (_error) {
     return { isAuthenticated: false };
   }

--- a/scripts/design/capture-responsive-design.mjs
+++ b/scripts/design/capture-responsive-design.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const OUTPUT_ROOT = path.join(ROOT, '.generated', 'design-captures');
+const FIXTURE_WALLET = '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD68';
+const MAX_CAPTURE_DIMENSION = Number(process.env.DESIGN_CAPTURE_MAX_DIMENSION ?? '2048');
+
+const VIEWPORTS = {
+  tablet: {
+    width: 834,
+    height: 1194,
+    isMobile: false,
+    hasTouch: true,
+    deviceScaleFactor: 2,
+  },
+  mobile: {
+    width: 390,
+    height: 844,
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 3,
+  },
+};
+
+const MODES = ['light', 'dark'];
+const TARGET_VIEWPORTS = (process.env.DESIGN_CAPTURE_VIEWPORTS ?? 'tablet,mobile')
+  .split(',')
+  .map((value) => value.trim())
+  .filter((value) => value in VIEWPORTS);
+const TARGET_STATES = new Set(
+  (process.env.DESIGN_CAPTURE_STATES ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+);
+
+const FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL ?? 'http://localhost:3000';
+const ADMIN_BASE_URL = process.env.ADMIN_BASE_URL ?? 'http://localhost:3001';
+
+function createRoute(route, { auth = false } = {}) {
+  return { route, auth };
+}
+
+const FRONTEND_STATES = {
+  about: createRoute('/about'),
+  'access-denied': createRoute('/access-denied'),
+  account: createRoute('/account', { auth: true }),
+  'account-credits': createRoute('/account/credits', { auth: true }),
+  'account-payments': createRoute('/account', { auth: true }),
+  'account-prefs': createRoute('/account', { auth: true }),
+  analytics: createRoute('/analytics'),
+  'analytics-auth': createRoute('/analytics', { auth: true }),
+  'analytics-default': createRoute('/analytics?sort_by=growth_factor', { auth: true }),
+  'analytics-filter-country': createRoute('/analytics?country=US', { auth: true }),
+  'analytics-filter-sector': createRoute('/analytics?sector=Technology', { auth: true }),
+  'analytics-pagination': createRoute('/analytics?page=2', { auth: true }),
+  'analytics-search': createRoute('/analytics?search=AAPL', { auth: true }),
+  'analytics-sort': createRoute('/analytics?sort_by=ranking_position', { auth: true }),
+  auth: createRoute('/auth'),
+  dashboard: createRoute('/dashboard', { auth: true }),
+  developer: createRoute('/developer', { auth: true }),
+  'developer-create-key': createRoute('/developer', { auth: true }),
+  'developer-docs': createRoute('/developer/docs', { auth: true }),
+  'developer-usage': createRoute('/developer/usage', { auth: true }),
+  home: createRoute('/'),
+  notifications: createRoute('/notifications', { auth: true }),
+  'notifications-default': createRoute('/notifications', { auth: true }),
+  'notifications-empty': createRoute('/notifications?page=999', { auth: true }),
+  'notifications-filter-priority': createRoute('/notifications?priority=high', { auth: true }),
+  'notifications-filter-type': createRoute('/notifications?type=security', { auth: true }),
+  'notifications-search': createRoute('/notifications', { auth: true }),
+  offline: createRoute('/offline'),
+  payment: createRoute('/payment?planId=1', { auth: true }),
+  'payment-detail': createRoute('/payment/link/1', { auth: true }),
+  permissions: createRoute('/permissions', { auth: true }),
+  plans: createRoute('/plans'),
+  portfolio: createRoute('/portfolio', { auth: true }),
+  'portfolio-search': createRoute('/portfolio', { auth: true }),
+  privacy: createRoute('/privacy'),
+  profile: createRoute('/profile', { auth: true }),
+  'profile-edit': createRoute('/profile', { auth: true }),
+  terms: createRoute('/terms'),
+};
+
+const ADMIN_STATES = {
+  'admin-access-denied': createRoute('/access-denied'),
+  'admin-access-overview': createRoute('/wallet-management/access', { auth: true }),
+  'admin-access-permissions': createRoute('/wallet-management/access', { auth: true }),
+  'admin-access-plan-detail': createRoute('/wallet-management/access/plans', { auth: true }),
+  'admin-access-plans': createRoute('/wallet-management/access/plans', { auth: true }),
+  'admin-analytics': createRoute('/analytics', { auth: true }),
+  'admin-api-docs': createRoute('/developer-portal?tab=docs', { auth: true }),
+  'admin-api-key-create': createRoute('/developer-portal/api-keys/create', { auth: true }),
+  'admin-audit-log': createRoute('/audit-log', { auth: true }),
+  'admin-audit-log-category': createRoute('/audit-log', { auth: true }),
+  'admin-audit-log-search': createRoute('/audit-log', { auth: true }),
+  'admin-auth': createRoute('/'),
+  'admin-dashboard': createRoute('/', { auth: true }),
+  'admin-dashboard-page': createRoute('/', { auth: true }),
+  'admin-developer-portal': createRoute('/developer-portal', { auth: true }),
+  'admin-notification-create': createRoute('/notifications/create', { auth: true }),
+  'admin-notification-create-filled': createRoute('/notifications/create', { auth: true }),
+  'admin-notification-manage': createRoute('/notifications/manage', { auth: true }),
+  'admin-notifications': createRoute('/notifications', { auth: true }),
+  'admin-payments': createRoute('/payments', { auth: true }),
+  'admin-plan-edit': createRoute('/wallet-management/access/plans', { auth: true }),
+  'admin-plan-new': createRoute('/wallet-management/access/plans', { auth: true }),
+  'admin-profile': createRoute('/settings', { auth: true }),
+  'admin-request-access': createRoute('/'),
+  'admin-settings': createRoute('/settings', { auth: true }),
+  'admin-settings-appearance': createRoute('/settings?tab=appearance', { auth: true }),
+  'admin-settings-notifications': createRoute('/settings?tab=notifications', { auth: true }),
+  'admin-settings-security': createRoute('/settings?tab=security', { auth: true }),
+  'admin-subscription-detail': createRoute('/payments?tab=user-access', { auth: true }),
+  'admin-subscription-new': createRoute('/payments?tab=payment-links', { auth: true }),
+  'admin-subscription-new-external': createRoute('/payments?tab=payment-links', { auth: true }),
+  'admin-subscription-new-filled': createRoute('/payments?tab=payment-links', { auth: true }),
+  'admin-unauthorized': createRoute('/unauthorized'),
+  'admin-wallet-activity': createRoute('/wallet-management/credits', { auth: true }),
+  'admin-wallet-credits': createRoute('/wallet-management/credits', { auth: true }),
+  'admin-wallet-detail': createRoute(`/wallet-management/${FIXTURE_WALLET}`, { auth: true }),
+  'admin-wallet-disable': createRoute(`/wallet-management/wallets/${FIXTURE_WALLET}/disable`, { auth: true }),
+  'admin-wallet-management': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-default': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-edit': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-filter-platform': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-filter-status': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-list': createRoute('/wallet-management/wallets', { auth: true }),
+  'admin-wallets-search': createRoute('/wallet-management/wallets', { auth: true }),
+};
+
+const CAPTURE_MATRIX = {
+  frontend: {
+    baseUrl: FRONTEND_BASE_URL,
+    states: FRONTEND_STATES,
+  },
+  admin: {
+    baseUrl: ADMIN_BASE_URL,
+    states: ADMIN_STATES,
+  },
+};
+
+function ensureDir(target) {
+  fs.mkdirSync(target, { recursive: true });
+}
+
+function normalizeCaptureSize(filePath) {
+  execFileSync('sips', ['-Z', String(MAX_CAPTURE_DIMENSION), filePath], {
+    stdio: 'ignore',
+  });
+}
+
+function withBypass(baseUrl, route, auth) {
+  const url = new URL(route, baseUrl);
+  if (auth) {
+    url.searchParams.set('__design_bypass', '1');
+  }
+  return url.toString();
+}
+
+async function navigate(page, url) {
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(600);
+}
+
+async function firstVisible(locator) {
+  try {
+    if (await locator.first().isVisible({ timeout: 1500 })) {
+      return locator.first();
+    }
+  } catch {}
+  return null;
+}
+
+async function clickIfVisible(page, locatorFactory) {
+  const locator = await firstVisible(locatorFactory(page));
+  if (locator !== null) {
+    await locator.click();
+    await page.waitForTimeout(500);
+    return true;
+  }
+  return false;
+}
+
+async function fillIfVisible(page, locatorFactory, value) {
+  const locator = await firstVisible(locatorFactory(page));
+  if (locator !== null) {
+    await locator.fill(value);
+    await page.waitForTimeout(500);
+    return true;
+  }
+  return false;
+}
+
+async function selectOption(page, labelText, optionText) {
+  const labels = page.locator('label').filter({ hasText: new RegExp(`^${labelText}$`, 'i') });
+  const label = await firstVisible(() => labels);
+  if (label !== null) {
+    const parent = label.locator('..');
+    const combobox = await firstVisible(() => parent.locator('[role="combobox"]'));
+    if (combobox !== null) {
+      await combobox.click();
+      await page.waitForTimeout(300);
+      const option = await firstVisible(() => page.getByRole('option', { name: new RegExp(optionText, 'i') }));
+      if (option !== null) {
+        await option.click();
+        await page.waitForTimeout(500);
+        return true;
+      }
+    }
+
+    const inputId = await label.getAttribute('for');
+    if (inputId !== null) {
+      const select = page.locator(`#${inputId}`);
+      if ((await select.count()) > 0) {
+        try {
+          await select.selectOption({ label: optionText });
+          await page.waitForTimeout(500);
+          return true;
+        } catch {}
+        try {
+          await select.selectOption(optionText);
+          await page.waitForTimeout(500);
+          return true;
+        } catch {}
+      }
+    }
+  }
+
+  const select = await firstVisible(() => page.getByRole('combobox', { name: new RegExp(labelText, 'i') }));
+  if (select !== null) {
+    await select.click();
+    await page.waitForTimeout(300);
+    const option = await firstVisible(() => page.getByRole('option', { name: new RegExp(optionText, 'i') }));
+    if (option !== null) {
+      await option.click();
+      await page.waitForTimeout(500);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function runFrontendAction(page, stateName) {
+  switch (stateName) {
+    case 'portfolio-search':
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/search stocks to add to watchlist/i),
+        'AAPL'
+      );
+      break;
+    case 'profile-edit':
+      await clickIfVisible(page, (currentPage) => currentPage.getByRole('tab', { name: /email/i }));
+      await clickIfVisible(page, (currentPage) => currentPage.getByRole('button', { name: /change email/i }));
+      break;
+    default:
+      break;
+  }
+}
+
+async function runAdminAction(page, stateName) {
+  switch (stateName) {
+    case 'admin-audit-log-search':
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/search by actor, action, or target/i),
+        'wallet'
+      );
+      break;
+    case 'admin-audit-log-category':
+      await clickIfVisible(page, (currentPage) => currentPage.getByRole('button', { name: /security/i }));
+      break;
+    case 'admin-notification-create-filled':
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/0x\.\.\./i),
+        FIXTURE_WALLET
+      );
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/payload designation/i),
+        'Design capture alert'
+      );
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/enter transmission data/i),
+        'Responsive mobile and tablet preview state.'
+      );
+      break;
+    case 'admin-plan-new':
+      await clickIfVisible(page, (currentPage) => currentPage.locator('button').filter({ has: currentPage.locator('svg.lucide-plus') }));
+      break;
+    case 'admin-plan-edit':
+    case 'admin-access-plan-detail':
+      await clickIfVisible(page, (currentPage) => currentPage.locator('a[href*="/wallet-management/access/plans/"], button').first());
+      break;
+    case 'admin-wallet-activity':
+      await clickIfVisible(page, (currentPage) => currentPage.getByRole('button', { name: /credit history/i }));
+      break;
+    case 'admin-wallets-filter-platform':
+      await selectOption(page, 'Platform', 'Analytics');
+      break;
+    case 'admin-wallets-filter-status':
+      await selectOption(page, 'Status', 'Disabled');
+      break;
+    case 'admin-wallets-search':
+      await fillIfVisible(
+        page,
+        (currentPage) => currentPage.getByPlaceholder(/search address, label, or note/i),
+        FIXTURE_WALLET.slice(0, 10)
+      );
+      break;
+    default:
+      break;
+  }
+}
+
+async function runStateAction(page, app, stateName) {
+  if (app === 'frontend') {
+    await runFrontendAction(page, stateName);
+    return;
+  }
+  await runAdminAction(page, stateName);
+}
+
+async function createContext(browser, baseUrl, mode, viewport) {
+  const context = await browser.newContext({
+    viewport: {
+      width: viewport.width,
+      height: viewport.height,
+    },
+    deviceScaleFactor: viewport.deviceScaleFactor,
+    isMobile: viewport.isMobile,
+    hasTouch: viewport.hasTouch,
+    colorScheme: mode,
+  });
+
+  await context.addInitScript((theme) => {
+    window.localStorage.setItem('theme', theme);
+    document.cookie = `theme=${theme}; path=/; SameSite=Lax`;
+    document.cookie = `__theme_mode=${theme}; path=/; SameSite=Lax`;
+  }, mode);
+
+  await context.addCookies([
+    { url: baseUrl, name: 'theme', value: mode },
+    { url: baseUrl, name: '__theme_mode', value: mode },
+  ]);
+
+  return context;
+}
+
+async function captureState(page, app, baseUrl, mode, viewportName, stateName, routeConfig, results) {
+  const targetUrl = withBypass(baseUrl, routeConfig.route, routeConfig.auth);
+  const outputDir = path.join(OUTPUT_ROOT, app, mode, viewportName);
+  const outputFile = path.join(outputDir, `${stateName}.jpg`);
+
+  ensureDir(outputDir);
+
+  try {
+    await navigate(page, targetUrl);
+    await runStateAction(page, app, stateName);
+    await page.screenshot({
+      path: outputFile,
+      fullPage: true,
+      type: 'jpeg',
+      quality: 85,
+    });
+    normalizeCaptureSize(outputFile);
+    results.generated.push({
+      app,
+      mode,
+      viewport: viewportName,
+      state: stateName,
+      file: outputFile,
+    });
+    console.log(`[capture] ok ${app}/${mode}/${viewportName}/${stateName}`);
+  } catch (error) {
+    results.failed.push({
+      app,
+      mode,
+      viewport: viewportName,
+      state: stateName,
+      file: outputFile,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    console.error(`[capture] failed ${app}/${mode}/${viewportName}/${stateName}: ${results.failed.at(-1)?.error}`);
+  }
+}
+
+async function main() {
+  ensureDir(OUTPUT_ROOT);
+
+  const browser = await chromium.launch({ headless: true });
+  const results = {
+    generated: [],
+    failed: [],
+    skipped: [],
+  };
+
+  try {
+    for (const [app, config] of Object.entries(CAPTURE_MATRIX)) {
+      for (const mode of MODES) {
+        for (const viewportName of TARGET_VIEWPORTS) {
+          const viewport = VIEWPORTS[viewportName];
+          const context = await createContext(browser, config.baseUrl, mode, viewport);
+          const page = await context.newPage();
+
+          for (const [stateName, routeConfig] of Object.entries(config.states)) {
+            if (TARGET_STATES.size > 0 && !TARGET_STATES.has(stateName)) {
+              results.skipped.push({
+                app,
+                mode,
+                viewport: viewportName,
+                state: stateName,
+                reason: 'state-filter',
+              });
+              continue;
+            }
+            await captureState(page, app, config.baseUrl, mode, viewportName, stateName, routeConfig, results);
+          }
+
+          await context.close();
+        }
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const reportPath = path.join(OUTPUT_ROOT, 'capture-report.json');
+  fs.writeFileSync(reportPath, JSON.stringify(results, null, 2));
+  console.log(`[capture] report ${reportPath}`);
+
+  if (results.failed.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/design/update-pencil-responsive.mjs
+++ b/scripts/design/update-pencil-responsive.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const HELPER = '/tmp/pencil-mcp-tool.js';
+const FILE_PATH = process.env.PENCIL_FILE ?? path.join('webDesign', 'AllDesign.pen');
+const CAPTURE_ROOT = path.join(ROOT, '.generated', 'design-captures');
+const VIEWPORTS = new Set(
+  (process.env.PENCIL_UPDATE_VIEWPORTS ?? 'desktop,tablet,mobile')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+);
+const SCREENSHOT_DIRS = {
+  frontend: path.join(ROOT, 'apps', 'frontend', 'public', 'screenshots'),
+  admin: path.join(ROOT, 'apps', 'admin-frontend', 'public', 'screenshots'),
+};
+const DEFAULT_EXTENSIONS = {
+  frontend: ['png', 'webp', 'jpg', 'jpeg'],
+  admin: ['png', 'webp', 'jpg', 'jpeg'],
+};
+
+function runPencil(command, payload) {
+  const raw = execFileSync('node', [HELPER, command, JSON.stringify(payload)], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+
+  const jsonStart = raw.indexOf('{');
+  const parsed = JSON.parse(raw.slice(jsonStart));
+  const text = parsed.content?.find((item) => item.type === 'text')?.text;
+  return text ?? '';
+}
+
+function loadBoards() {
+  const responseText = runPencil('batch_get', {
+    filePath: FILE_PATH,
+    nodeIds: ['SAOta', 'ZFtTR', 'H4QsI', 'jG32H'],
+    readDepth: 6,
+    resolveVariables: true,
+  });
+  return JSON.parse(responseText);
+}
+
+function walkNodes(node, context, records) {
+  const nextContext = { ...context };
+
+  if (typeof node?.name === 'string') {
+    if (node.name.includes('Frontend')) {
+      nextContext.app = 'frontend';
+      nextContext.mode = node.name.toLowerCase().includes('dark') ? 'dark' : 'light';
+    } else if (node.name.includes('Admin')) {
+      nextContext.app = 'admin';
+      nextContext.mode = node.name.toLowerCase().includes('dark') ? 'dark' : 'light';
+    }
+
+    if (
+      node.children !== undefined &&
+      Array.isArray(node.children) &&
+      node.children.some(
+        (child) => typeof child?.name === 'string' && child.name === 'Responsive Frames'
+      )
+    ) {
+      nextContext.state = node.name;
+    }
+  }
+
+  if (
+    nextContext.app !== undefined &&
+    nextContext.mode !== undefined &&
+    nextContext.state !== undefined &&
+    typeof node?.name === 'string' &&
+    ['Desktop', 'Tablet', 'Mobile'].includes(node.name) &&
+    node.fill?.type === 'image'
+  ) {
+    records.push({
+      nodeId: node.id,
+      app: nextContext.app,
+      mode: nextContext.mode,
+      state: nextContext.state,
+      viewport: node.name.toLowerCase(),
+      currentUrl: node.fill.url,
+    });
+  }
+
+  if (Array.isArray(node?.children)) {
+    for (const child of node.children) {
+      walkNodes(child, nextContext, records);
+    }
+  }
+}
+
+function buildUpdateRecords(boardTree) {
+  const records = [];
+  for (const board of boardTree) {
+    walkNodes(board, {}, records);
+  }
+  return records;
+}
+
+function chunk(items, size) {
+  const result = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}
+
+function buildOperation(record, targetPath) {
+  return `U(${JSON.stringify(record.nodeId)},{fill:{enabled:true,mode:"fit",type:"image",url:${JSON.stringify(targetPath)}}})`;
+}
+
+function resolveScreenshotPath(record) {
+  const screenshotDir = SCREENSHOT_DIRS[record.app];
+  const candidates = [];
+  const basename = typeof record.currentUrl === 'string' ? path.basename(record.currentUrl) : '';
+
+  for (const extension of DEFAULT_EXTENSIONS[record.app] ?? []) {
+    candidates.push(path.join(screenshotDir, `${record.state}.${extension}`));
+  }
+
+  if (basename !== '') {
+    candidates.push(path.join(screenshotDir, basename));
+  }
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveTargetPath(record) {
+  if (record.viewport !== 'desktop') {
+    const capturePath = path.join(
+      CAPTURE_ROOT,
+      record.app,
+      record.mode,
+      record.viewport,
+      `${record.state}.jpg`
+    );
+
+    if (fs.existsSync(capturePath)) {
+      return {
+        targetPath: capturePath,
+        source: 'responsive-capture',
+      };
+    }
+  }
+
+  const screenshotPath = resolveScreenshotPath(record);
+  if (screenshotPath !== null) {
+    return {
+      targetPath: screenshotPath,
+      source: record.viewport === 'desktop' ? 'repo-screenshot' : 'repo-screenshot-fallback',
+    };
+  }
+
+  return null;
+}
+
+function main() {
+  const boards = loadBoards();
+  const records = buildUpdateRecords(boards).filter((record) => VIEWPORTS.has(record.viewport));
+
+  const updates = [];
+  const skipped = [];
+
+  for (const record of records) {
+    const resolved = resolveTargetPath(record);
+
+    if (resolved === null) {
+      skipped.push({ ...record, reason: 'asset-missing' });
+      continue;
+    }
+
+    updates.push({ ...record, ...resolved });
+  }
+
+  for (const group of chunk(updates, 24)) {
+    const operations = group
+      .map((item) => buildOperation(item, item.targetPath))
+      .join('\n');
+    runPencil('batch_design', {
+      filePath: FILE_PATH,
+      operations,
+    });
+  }
+
+  const report = {
+    updated: updates,
+    skipped,
+  };
+
+  const reportPath = path.join(CAPTURE_ROOT, 'pencil-update-report.json');
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+  console.log(JSON.stringify({
+    updated: updates.length,
+    skipped: skipped.length,
+    reportPath,
+  }, null, 2));
+}
+
+main();

--- a/shared/auth/middleware.ts
+++ b/shared/auth/middleware.ts
@@ -1,17 +1,24 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { logger } from '../utils/logger';
+import {
+  DESIGN_BYPASS_COOKIE,
+  DESIGN_BYPASS_HEADER,
+  DESIGN_BYPASS_QUERY_PARAM,
+  isDesignBypassRequestEnabled,
+  isDesignBypassTruthy,
+} from '../utils/design-bypass';
 import { COOKIES, getServerAuthToken } from './cookies';
 
 export interface AuthMiddlewareConfig {
-    /** The path to redirect to for login */
-    loginPath?: string;
-    /** The path to redirect to after successful login if no return URL */
-    homePath?: string;
-/** List of public routes that don't require authentication */
-    publicRoutes?: string[];
-    /** If true, the middleware will not redirect, only set headers */
-    noRedirect?: boolean;
+  /** The path to redirect to for login */
+  loginPath?: string;
+  /** The path to redirect to after successful login if no return URL */
+  homePath?: string;
+  /** List of public routes that don't require authentication */
+  publicRoutes?: string[];
+  /** If true, the middleware will not redirect, only set headers */
+  noRedirect?: boolean;
 }
 
 /**
@@ -19,234 +26,353 @@ export interface AuthMiddlewareConfig {
  * Implements security headers and route protection.
  */
 export function createAuthMiddleware(config: AuthMiddlewareConfig) {
-    const loginPath = config.loginPath ?? '/auth';
-    const homePath = config.homePath ?? '/';
-    const publicRoutes = config.publicRoutes;
-    const noRedirect = config.noRedirect ?? false;
+  const loginPath = config.loginPath ?? '/auth';
+  const homePath = config.homePath ?? '/';
+  const publicRoutes = config.publicRoutes;
+  const noRedirect = config.noRedirect ?? false;
 
-    return function authMiddleware(request: NextRequest) {
-        const { pathname, search } = request.nextUrl;
-        const startTime = performance.now();
+  return function authMiddleware(request: NextRequest) {
+    const { pathname, search } = request.nextUrl;
+    const startTime = performance.now();
 
-        // 0. Logout via middleware — clears __Host- cookies at HTTP level
-        // Server action Set-Cookie headers can be lost through Cloudflare Tunnel;
-        // middleware Set-Cookie on a redirect is a raw HTTP response that always works.
-        if (request.nextUrl.searchParams.has('logout')) {
-            const cleanUrl = new URL(pathname, request.url);
-            const resp = NextResponse.redirect(cleanUrl);
-            [COOKIES.access_token, COOKIES.refresh_token, COOKIES.id_token,
-             COOKIES.user, COOKIES.sid, COOKIES.auth_time, COOKIES.expires_at].forEach(name => {
-                // __Host- prefix requires Secure flag per spec; derive from name, not NODE_ENV
-                resp.cookies.set(name, '', { maxAge: 0, secure: name.startsWith('__Host-'), sameSite: 'lax', path: '/' });
-            });
-            return resp;
-        }
-
-        // 1. Initialize Response and Headers
-        const response = NextResponse.next();
-        applySecurityHeaders(response, pathname);
-
-        // 2. Validate Authentication — use unified token resolution (sid → access_token → user.access)
-        const token = getServerAuthToken(request.cookies);
-        const isAuthenticated = token !== null;
-
-        logger.debug('[AUTH] Middleware Auth Check:', {
-            pathname,
-            hasToken: Boolean(token),
-            isAuthenticated,
-            allCookies: request.cookies.getAll().map(c => c.name),
+    // 0. Logout via middleware — clears __Host- cookies at HTTP level
+    // Server action Set-Cookie headers can be lost through Cloudflare Tunnel;
+    // middleware Set-Cookie on a redirect is a raw HTTP response that always works.
+    if (request.nextUrl.searchParams.has('logout')) {
+      const cleanUrl = new URL(pathname, request.url);
+      const resp = NextResponse.redirect(cleanUrl);
+      [
+        COOKIES.access_token,
+        COOKIES.refresh_token,
+        COOKIES.id_token,
+        COOKIES.user,
+        COOKIES.sid,
+        COOKIES.auth_time,
+        COOKIES.expires_at,
+      ].forEach(name => {
+        // __Host- prefix requires Secure flag per spec; derive from name, not NODE_ENV
+        resp.cookies.set(name, '', {
+          maxAge: 0,
+          secure: name.startsWith('__Host-'),
+          sameSite: 'lax',
+          path: '/',
         });
+      });
+      return resp;
+    }
 
-        // 3. Check Route Accessibility
-        const isPublicRoute = checkIsPublicRoute(pathname, publicRoutes);
+    const bypassEnabled = isDesignBypassRequestEnabled(
+      request.nextUrl.searchParams,
+      request.cookies.get(DESIGN_BYPASS_COOKIE)?.value
+    );
 
-        logger.debug('[AUTH] Middleware Route Check:', {
-            pathname,
-            isPublicRoute,
-            loginPath,
-            homePath,
-        });
+    const requestHeaders = new Headers(request.headers);
+    if (bypassEnabled) {
+      requestHeaders.set(DESIGN_BYPASS_HEADER, '1');
+    }
 
-        // 4. Handle Redirection Logic
-        const redirectResponse = handleRedirects(
-            request,
-            { isAuthenticated, isPublicRoute },
-            { pathname, search, loginPath, homePath, noRedirect }
-        );
+    // 1. Initialize Response and Headers
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
+    applySecurityHeaders(response, pathname);
 
-        if (redirectResponse) {
-            return redirectResponse;
+    if (request.nextUrl.searchParams.has(DESIGN_BYPASS_QUERY_PARAM)) {
+      const raw = request.nextUrl.searchParams.get(DESIGN_BYPASS_QUERY_PARAM);
+      response.cookies.set(
+        DESIGN_BYPASS_COOKIE,
+        isDesignBypassTruthy(raw) ? '1' : '',
+        {
+          httpOnly: true,
+          secure: DESIGN_BYPASS_COOKIE.startsWith('__Host-'),
+          sameSite: 'lax',
+          path: '/',
+          maxAge: isDesignBypassTruthy(raw) ? 60 * 60 : 0,
         }
+      );
+    }
 
-        // 5. Finalize Response
-        const elapsedTime = performance.now() - startTime;
-        response.headers.set('x-middleware-performance', elapsedTime.toString());
+    if (bypassEnabled) {
+      response.headers.set(DESIGN_BYPASS_HEADER, '1');
+      return response;
+    }
 
-        return response;
-    };
+    // 2. Validate Authentication — use unified token resolution (sid → access_token → user.access)
+    const token = getServerAuthToken(request.cookies);
+    const isAuthenticated = token !== null;
+
+    logger.debug('[AUTH] Middleware Auth Check:', {
+      pathname,
+      hasToken: Boolean(token),
+      isAuthenticated,
+      allCookies: request.cookies.getAll().map(c => c.name),
+    });
+
+    // 3. Check Route Accessibility
+    const isPublicRoute = checkIsPublicRoute(pathname, publicRoutes);
+
+    logger.debug('[AUTH] Middleware Route Check:', {
+      pathname,
+      isPublicRoute,
+      loginPath,
+      homePath,
+    });
+
+    // 4. Handle Redirection Logic
+    const redirectResponse = handleRedirects(
+      request,
+      { isAuthenticated, isPublicRoute },
+      { pathname, search, loginPath, homePath, noRedirect }
+    );
+
+    if (redirectResponse) {
+      return redirectResponse;
+    }
+
+    // 5. Finalize Response
+    const elapsedTime = performance.now() - startTime;
+    response.headers.set('x-middleware-performance', elapsedTime.toString());
+
+    return response;
+  };
 }
 
 /**
  * Orchestrates redirection logic for different authentication scenarios.
  */
 function handleRedirects(
-    request: NextRequest,
-    authStatus: { isAuthenticated: boolean; isPublicRoute: boolean },
-    context: { pathname: string; search: string; loginPath: string; homePath: string; noRedirect: boolean }
-): NextResponse | null {
-    const { isAuthenticated, isPublicRoute } = authStatus;
-    const { pathname, search, loginPath, homePath, noRedirect } = context;
-
-    // Case A: Unauthenticated User on Protected Route
-    if (!isAuthenticated && !isPublicRoute) {
-        return handleUnauthenticated({ request, pathname, search, loginPath, noRedirect });
-    }
-
-    // Case C: Authenticated User on Login Page (checked before Case B so return_url redirect works)
-    if (isAuthenticated && pathname === loginPath) {
-        return handleAuthenticatedOnLogin(request, { homePath, loginPath, noRedirect });
-    }
-
-    // Case B: Explicit Login request with return_url (unauthenticated users only)
-    if (pathname === loginPath && request.nextUrl.searchParams.has('return_url')) {
-        return handleExplicitReturnUrl(request, loginPath);
-    }
-
-    return null;
-}
-
-interface UnauthenticatedContext {
-    request: NextRequest;
+  request: NextRequest,
+  authStatus: { isAuthenticated: boolean; isPublicRoute: boolean },
+  context: {
     pathname: string;
     search: string;
     loginPath: string;
+    homePath: string;
     noRedirect: boolean;
+  }
+): NextResponse | null {
+  const { isAuthenticated, isPublicRoute } = authStatus;
+  const { pathname, search, loginPath, homePath, noRedirect } = context;
+
+  // Case A: Unauthenticated User on Protected Route
+  if (!isAuthenticated && !isPublicRoute) {
+    return handleUnauthenticated({
+      request,
+      pathname,
+      search,
+      loginPath,
+      noRedirect,
+    });
+  }
+
+  // Case C: Authenticated User on Login Page (checked before Case B so return_url redirect works)
+  if (isAuthenticated && pathname === loginPath) {
+    return handleAuthenticatedOnLogin(request, {
+      homePath,
+      loginPath,
+      noRedirect,
+    });
+  }
+
+  // Case B: Explicit Login request with return_url (unauthenticated users only)
+  if (
+    pathname === loginPath &&
+    request.nextUrl.searchParams.has('return_url')
+  ) {
+    return handleExplicitReturnUrl(request, loginPath);
+  }
+
+  return null;
 }
 
-function handleUnauthenticated(context: UnauthenticatedContext): NextResponse | null {
-    const { request, pathname, search, loginPath, noRedirect } = context;
-    if (noRedirect) { return null; }
-
-    const responseRedirect = NextResponse.redirect(new URL(loginPath, request.url));
-    const invalidPrefixes = ['/.well-known', '/_next', '/api', '/favicon', '/static'];
-    const isValidReturnPath = !invalidPrefixes.some(p => pathname.startsWith(p));
-
-    if (pathname !== '/' && isValidReturnPath) {
-        responseRedirect.cookies.set(COOKIES.return_url, pathname + search, {
-            httpOnly: true,
-            secure: COOKIES.return_url.startsWith('__Host-'),
-            sameSite: 'lax',
-            path: '/',
-            maxAge: 300 // 5 minutes
-        });
-    }
-
-    responseRedirect.headers.set('x-reason', 'no-session');
-    return responseRedirect;
+interface UnauthenticatedContext {
+  request: NextRequest;
+  pathname: string;
+  search: string;
+  loginPath: string;
+  noRedirect: boolean;
 }
 
-function handleExplicitReturnUrl(request: NextRequest, loginPath: string): NextResponse | null {
-    const returnUrl = request.nextUrl.searchParams.get('return_url');
-    if (returnUrl !== null && returnUrl !== '' && returnUrl !== loginPath && !returnUrl.startsWith(`${loginPath}?`)) {
-        const existingReturnUrl = request.cookies.get(COOKIES.return_url)?.value;
-        if (existingReturnUrl === returnUrl) {
-            return null;
-        }
-
-        // Pass through (keep return_url in URL) and also set cookie as backup
-        const response = NextResponse.next();
-        response.cookies.set(COOKIES.return_url, returnUrl, {
-            httpOnly: true,
-            secure: COOKIES.return_url.startsWith('__Host-'),
-            sameSite: 'lax',
-            path: '/',
-            maxAge: 300
-        });
-
-        logger.info('[AUTH] Middleware: Setting return_url cookie', { returnUrl });
-        return response;
-    }
+function handleUnauthenticated(
+  context: UnauthenticatedContext
+): NextResponse | null {
+  const { request, pathname, search, loginPath, noRedirect } = context;
+  if (noRedirect) {
     return null;
+  }
+
+  const responseRedirect = NextResponse.redirect(
+    new URL(loginPath, request.url)
+  );
+  const invalidPrefixes = [
+    '/.well-known',
+    '/_next',
+    '/api',
+    '/favicon',
+    '/static',
+  ];
+  const isValidReturnPath = !invalidPrefixes.some(p => pathname.startsWith(p));
+
+  if (pathname !== '/' && isValidReturnPath) {
+    responseRedirect.cookies.set(COOKIES.return_url, pathname + search, {
+      httpOnly: true,
+      secure: COOKIES.return_url.startsWith('__Host-'),
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 300, // 5 minutes
+    });
+  }
+
+  responseRedirect.headers.set('x-reason', 'no-session');
+  return responseRedirect;
+}
+
+function handleExplicitReturnUrl(
+  request: NextRequest,
+  loginPath: string
+): NextResponse | null {
+  const returnUrl = request.nextUrl.searchParams.get('return_url');
+  if (
+    returnUrl !== null &&
+    returnUrl !== '' &&
+    returnUrl !== loginPath &&
+    !returnUrl.startsWith(`${loginPath}?`)
+  ) {
+    const existingReturnUrl = request.cookies.get(COOKIES.return_url)?.value;
+    if (existingReturnUrl === returnUrl) {
+      return null;
+    }
+
+    // Pass through (keep return_url in URL) and also set cookie as backup
+    const response = NextResponse.next();
+    response.cookies.set(COOKIES.return_url, returnUrl, {
+      httpOnly: true,
+      secure: COOKIES.return_url.startsWith('__Host-'),
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 300,
+    });
+
+    logger.info('[AUTH] Middleware: Setting return_url cookie', { returnUrl });
+    return response;
+  }
+  return null;
 }
 
 function handleAuthenticatedOnLogin(
-    request: NextRequest,
-    options: { homePath: string; loginPath: string; noRedirect: boolean }
+  request: NextRequest,
+  options: { homePath: string; loginPath: string; noRedirect: boolean }
 ): NextResponse | null {
-    const { homePath, noRedirect } = options;
-    if (noRedirect) { return null; }
+  const { homePath, noRedirect } = options;
+  if (noRedirect) {
+    return null;
+  }
 
-    // Break infinite redirect loop if token is expired but cookie isn't cleared
-    if (request.nextUrl.searchParams.get('reason') === 'no-session' || request.nextUrl.searchParams.has('clear')) {
-        const responseNext = NextResponse.next();
-        // Use set(maxAge=0) — delete() omits Secure flag, failing to remove __Host- cookies
-        [COOKIES.access_token, COOKIES.refresh_token, COOKIES.id_token,
-         COOKIES.user, COOKIES.sid, COOKIES.auth_time, COOKIES.expires_at].forEach(name => {
-            responseNext.cookies.set(name, '', { maxAge: 0, secure: name.startsWith('__Host-'), sameSite: 'lax', path: '/' });
-        });
-        return responseNext;
-    }
+  // Break infinite redirect loop if token is expired but cookie isn't cleared
+  if (
+    request.nextUrl.searchParams.get('reason') === 'no-session' ||
+    request.nextUrl.searchParams.has('clear')
+  ) {
+    const responseNext = NextResponse.next();
+    // Use set(maxAge=0) — delete() omits Secure flag, failing to remove __Host- cookies
+    [
+      COOKIES.access_token,
+      COOKIES.refresh_token,
+      COOKIES.id_token,
+      COOKIES.user,
+      COOKIES.sid,
+      COOKIES.auth_time,
+      COOKIES.expires_at,
+    ].forEach(name => {
+      responseNext.cookies.set(name, '', {
+        maxAge: 0,
+        secure: name.startsWith('__Host-'),
+        sameSite: 'lax',
+        path: '/',
+      });
+    });
+    return responseNext;
+  }
 
-    // If user explicitly navigated to /auth with return_url, let the page render.
-    // Middleware can only check cookies, not wallet connection state (client-side).
-    // The auth page handles redirect when both authenticated AND wallet connected.
-    if (request.nextUrl.searchParams.has('return_url')) {
-        return null;
-    }
+  // If user explicitly navigated to /auth with return_url, let the page render.
+  // Middleware can only check cookies, not wallet connection state (client-side).
+  // The auth page handles redirect when both authenticated AND wallet connected.
+  if (request.nextUrl.searchParams.has('return_url')) {
+    return null;
+  }
 
-    const returnUrlCookie = request.cookies.get(COOKIES.return_url)?.value;
-    const targetPath = returnUrlCookie ?? homePath;
+  const returnUrlCookie = request.cookies.get(COOKIES.return_url)?.value;
+  const targetPath = returnUrlCookie ?? homePath;
 
-    logger.info('[AUTH] Middleware: Authenticated user on login page, redirecting', { targetPath });
+  logger.info(
+    '[AUTH] Middleware: Authenticated user on login page, redirecting',
+    { targetPath }
+  );
 
-    const responseRedirect = NextResponse.redirect(new URL(targetPath, request.url));
-    responseRedirect.cookies.delete(COOKIES.return_url);
-    return responseRedirect;
+  const responseRedirect = NextResponse.redirect(
+    new URL(targetPath, request.url)
+  );
+  responseRedirect.cookies.delete(COOKIES.return_url);
+  return responseRedirect;
 }
 
 /**
  * Checks if a path is considered a public route.
  */
-function checkIsPublicRoute(pathname: string, publicRoutes: string[] | undefined): boolean {
-    if (!publicRoutes) { return false; }
-    return publicRoutes.some(route => {
-        if (route.endsWith('*')) {
-            return pathname.startsWith(route.slice(0, -1));
-        }
-        return pathname === route;
-    });
+function checkIsPublicRoute(
+  pathname: string,
+  publicRoutes: string[] | undefined
+): boolean {
+  if (!publicRoutes) {
+    return false;
+  }
+  return publicRoutes.some(route => {
+    if (route.endsWith('*')) {
+      return pathname.startsWith(route.slice(0, -1));
+    }
+    return pathname === route;
+  });
 }
 
 /**
  * Applies security headers to the response.
  */
 function applySecurityHeaders(response: NextResponse, pathname: string) {
-    const headers = response.headers;
-    const isProd = process.env.NODE_ENV === 'production';
+  const headers = response.headers;
+  const isProd = process.env.NODE_ENV === 'production';
 
-    // Standard security headers
-    headers.set('X-DNS-Prefetch-Control', 'on');
-    // Allow same-origin iframe for Scalar API docs
-    const frameOpts = pathname === '/developer/docs/reference' ? 'SAMEORIGIN' : 'DENY';
-    headers.set('X-Frame-Options', frameOpts);
-    headers.set('X-Content-Type-Options', 'nosniff');
-    headers.set('X-XSS-Protection', '1; mode=block');
-    headers.set('Referrer-Policy', 'origin-when-cross-origin');
-    headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+  // Standard security headers
+  headers.set('X-DNS-Prefetch-Control', 'on');
+  // Allow same-origin iframe for Scalar API docs
+  const frameOpts =
+    pathname === '/developer/docs/reference' ? 'SAMEORIGIN' : 'DENY';
+  headers.set('X-Frame-Options', frameOpts);
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('X-XSS-Protection', '1; mode=block');
+  headers.set('Referrer-Policy', 'origin-when-cross-origin');
+  headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(), payment=()'
+  );
 
-    // HSTS - enforce HTTPS in production
-    if (isProd) {
-        headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-    }
+  // HSTS - enforce HTTPS in production
+  if (isProd) {
+    headers.set(
+      'Strict-Transport-Security',
+      'max-age=31536000; includeSubDomains'
+    );
+  }
 
-    // CSP is set via <meta> tag in layout.tsx — NOT as an HTTP header.
-    // Cloudflare Tunnel strips `static.cloudflareinsights.com` and `script-src-elem`
-    // from HTTP headers, and when both header + meta exist the browser enforces
-    // the intersection (most restrictive wins), so the stripped header blocks
-    // the Cloudflare analytics beacon. Meta tag alone works correctly.
+  // CSP is set via <meta> tag in layout.tsx — NOT as an HTTP header.
+  // Cloudflare Tunnel strips `static.cloudflareinsights.com` and `script-src-elem`
+  // from HTTP headers, and when both header + meta exist the browser enforces
+  // the intersection (most restrictive wins), so the stripped header blocks
+  // the Cloudflare analytics beacon. Meta tag alone works correctly.
 
-    // Conditional caching headers
-    if (pathname.includes('/api/')) {
-        headers.set('Cache-Control', 'no-store, max-age=0, must-revalidate');
-    }
+  // Conditional caching headers
+  if (pathname.includes('/api/')) {
+    headers.set('Cache-Control', 'no-store, max-age=0, must-revalidate');
+  }
 }

--- a/shared/utils/design-bypass.ts
+++ b/shared/utils/design-bypass.ts
@@ -1,0 +1,157 @@
+import type { UserInfoResponse } from '../auth/client';
+import type { EPSXJWTPayload } from '../auth/jwt';
+import type { User } from '../types/auth';
+
+const TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export const DESIGN_BYPASS_ENV_VAR = 'EPSX_DESIGN_BYPASS';
+export const DESIGN_BYPASS_COOKIE = 'epsx_design_bypass';
+export const DESIGN_BYPASS_QUERY_PARAM = '__design_bypass';
+export const DESIGN_BYPASS_HEADER = 'x-epsx-design-bypass';
+export const DESIGN_BYPASS_WALLET =
+  '0xDe51gnBYP4550000000000000000000000000001';
+export const DESIGN_BYPASS_EMAIL = 'design-mode@epsx.local';
+export const DESIGN_BYPASS_NAME = 'EPSX Design Mode';
+
+const FRONTEND_PERMISSIONS = [
+  'epsx:analytics:view',
+  'epsx:portfolio:view',
+  'epsx:plans:view',
+  'epsx:notifications:view',
+  'epsx:developer:view',
+  'epsx:profile:manage',
+  'epsx:account:manage',
+  'epsx:payments:view',
+];
+
+const ADMIN_PERMISSIONS = [
+  'admin:*:*',
+  'admin:analytics:view',
+  'admin:wallets:manage',
+  'admin:plans:manage',
+  'admin:permissions:manage',
+  'admin:developer:manage',
+  'admin:notifications:manage',
+  'admin:audit:view',
+];
+
+export function isDesignBypassTruthy(raw: string | null | undefined): boolean {
+  return TRUTHY_VALUES.has(raw?.trim().toLowerCase() ?? '');
+}
+
+export function isDesignBypassEnabled(): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  return isDesignBypassTruthy(process.env[DESIGN_BYPASS_ENV_VAR]);
+}
+
+export function isDesignBypassRequestEnabled(
+  searchParams?: URLSearchParams,
+  cookieValue?: string | null
+): boolean {
+  if (isDesignBypassEnabled()) {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  return (
+    isDesignBypassTruthy(searchParams?.get(DESIGN_BYPASS_QUERY_PARAM)) ||
+    isDesignBypassTruthy(cookieValue)
+  );
+}
+
+export async function isDesignBypassServerEnabled(): Promise<boolean> {
+  if (isDesignBypassEnabled()) {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  try {
+    const { cookies, headers } = await import('next/headers');
+    const headersList = await headers();
+    if (isDesignBypassTruthy(headersList.get(DESIGN_BYPASS_HEADER))) {
+      return true;
+    }
+
+    const cookieStore = await cookies();
+    return isDesignBypassTruthy(cookieStore.get(DESIGN_BYPASS_COOKIE)?.value);
+  } catch {
+    return false;
+  }
+}
+
+export function getDesignBypassPermissions(
+  kind: 'frontend' | 'admin' | 'all' = 'all'
+): string[] {
+  if (kind === 'frontend') {
+    return [...FRONTEND_PERMISSIONS];
+  }
+
+  if (kind === 'admin') {
+    return [...FRONTEND_PERMISSIONS, ...ADMIN_PERMISSIONS];
+  }
+
+  return [...FRONTEND_PERMISSIONS, ...ADMIN_PERMISSIONS];
+}
+
+export function getDesignBypassUserInfo(
+  kind: 'frontend' | 'admin' = 'frontend'
+): UserInfoResponse {
+  return {
+    sub: DESIGN_BYPASS_WALLET,
+    wallet_address: DESIGN_BYPASS_WALLET,
+    tier_level: 'enterprise',
+    auth_method: 'design_bypass',
+    permissions: getDesignBypassPermissions(kind),
+    email: DESIGN_BYPASS_EMAIL,
+    access: 'design-bypass',
+    packageTier: 'enterprise',
+    group: kind === 'admin' ? 'admin' : 'design',
+    is_admin: kind === 'admin',
+  };
+}
+
+export function getDesignBypassFrontendUser(): User {
+  return {
+    id: DESIGN_BYPASS_WALLET,
+    email: DESIGN_BYPASS_EMAIL,
+    name: DESIGN_BYPASS_NAME,
+    permissions: getDesignBypassPermissions('frontend'),
+    plan: 'enterprise',
+    platform_context: 'epsx',
+    tier: 'enterprise',
+    verified: true,
+    enterpriseTier: 'enterprise',
+    hasApiAccess: true,
+    verifiedTokensUsd: 1_000_000,
+    nftCollections: [],
+    daoMemberships: [],
+  };
+}
+
+export function getDesignBypassAdminPayload(): EPSXJWTPayload {
+  const now = Math.floor(Date.now() / 1000);
+
+  return {
+    sub: DESIGN_BYPASS_WALLET,
+    email: DESIGN_BYPASS_EMAIL,
+    name: DESIGN_BYPASS_NAME,
+    permissions: getDesignBypassPermissions('admin'),
+    iat: now,
+    exp: now + 60 * 60,
+    id: DESIGN_BYPASS_WALLET,
+    role: 'super_admin',
+    package_tier: 'enterprise',
+    platforms: ['epsx', 'admin'],
+    primary_platform: 'admin',
+    platform_context: 'admin',
+  };
+}


### PR DESCRIPTION
## What changed
- add a shared design bypass utility that can simulate authenticated frontend and admin sessions outside production
- thread the bypass through shared and admin middleware, session helpers, and auth redirects so protected routes can render without real auth cookies during design work
- add design capture scripts that use the bypass to gather responsive screenshots for protected pages

## Why
Protected routes were blocking design capture and review work for authenticated flows. This adds a non-production bypass path that keeps design tooling moving without weakening production auth.

## Impact
- frontend and admin protected routes can be opened in design mode outside production
- admin 403 redirects now tolerate the bypass path during design capture
- responsive design capture tooling can reach authenticated routes without manual login setup

## Validation
- `git diff --check`
- `bun run lint:frontend`
- `bun run lint:admin`
- `ENV=development DEPLOYMENT_ENV=development NODE_ENV=production bun run build:frontend`
- `ENV=development DEPLOYMENT_ENV=development NODE_ENV=production bun run build:admin`
