### PR TITLE
fix: persist wallet favorites into portfolio

### DIFF
--- a/apps/backend/src/web/user/unified_user_handlers.rs
+++ b/apps/backend/src/web/user/unified_user_handlers.rs
@@ -10,23 +10,32 @@
 //! - Frontend displays exactly what backend tells it to display
 //! - No permission logic in handlers - middleware handles auth
 
+use crate::web::middleware::OpenIDUserContext;
 use axum::{
-    extract::{Path, Query, Request, State, Extension},
+    extract::{Extension, Path, Query, Request, State},
     Json,
 };
-use crate::web::middleware::OpenIDUserContext;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tracing::{error, info};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::{error, info, warn};
 use utoipa::ToSchema;
 
 use crate::{
+    domain::shared_kernel::entities::eps_growth::EPSRanking,
+    infrastructure::adapters::services::tradingview::TradingViewApiService,
     web::{
+        analytics::convert_screening_result_to_eps_ranking,
+        analytics::eps::transform::{
+            transform_ranking_to_unified_format, transform_unified_to_card_format,
+        },
+        analytics::eps::types::SymbolCardData,
         auth::AppState,
-        middleware::{require_user_context, check_user_permission},
-        responses::{UnifiedApiResponse, ResponseMeta, PermissionContext},
+        middleware::{check_user_permission, require_user_context},
+        responses::{PermissionContext, ResponseMeta, UnifiedApiResponse},
     },
 };
 
@@ -115,7 +124,11 @@ pub async fn get_current_user_profile(
     // Extract user context from validated Bearer token (handled by middleware)
     let user_context = match require_user_context(&request) {
         Ok(context) => context,
-        Err(_auth_error) => return Err(Json(UnifiedApiResponse::auth_error("Valid Bearer token required"))),
+        Err(_auth_error) => {
+            return Err(Json(UnifiedApiResponse::auth_error(
+                "Valid Bearer token required",
+            )))
+        }
     };
 
     info!(
@@ -137,7 +150,9 @@ pub async fn get_current_user_profile(
                     created_at: now.clone(),
                     last_login: now,
                 },
-                ResponseMeta::default().with_permissions(PermissionContext::from_permissions(&user_context.permissions)),
+                ResponseMeta::default().with_permissions(PermissionContext::from_permissions(
+                    &user_context.permissions,
+                )),
             )));
         }
     };
@@ -151,7 +166,7 @@ pub async fn get_current_user_profile(
     }
 
     let (created_at, last_login) = match diesel::sql_query(
-        "SELECT created_at, last_auth_at FROM wallet_users WHERE wallet_address = $1"
+        "SELECT created_at, last_auth_at FROM wallet_users WHERE wallet_address = $1",
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .get_result::<UserRow>(&mut conn)
@@ -160,7 +175,9 @@ pub async fn get_current_user_profile(
     {
         Ok(Some(row)) => (
             row.created_at.unwrap_or_else(chrono::Utc::now).to_rfc3339(),
-            row.last_auth_at.unwrap_or_else(chrono::Utc::now).to_rfc3339(),
+            row.last_auth_at
+                .unwrap_or_else(chrono::Utc::now)
+                .to_rfc3339(),
         ),
         _ => {
             // Fallback to current time if user not found in database
@@ -217,16 +234,27 @@ pub async fn get_user_access_overview(
     // Extract user context
     let user_context = match require_user_context(&request) {
         Ok(context) => context,
-        Err(_) => return Err(Json(UnifiedApiResponse::auth_error("Valid Bearer token required"))),
+        Err(_) => {
+            return Err(Json(UnifiedApiResponse::auth_error(
+                "Valid Bearer token required",
+            )))
+        }
     };
 
-    info!("Getting access overview for user: {}", user_context.wallet_address);
+    info!(
+        "Getting access overview for user: {}",
+        user_context.wallet_address
+    );
 
     let mut conn = match _app_state.db_pool.get().await {
         Ok(c) => c,
         Err(e) => {
             error!("Failed to get database connection: {}", e);
-            return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to connect to database")));
+            return Err(Json(UnifiedApiResponse::error(
+                500,
+                "Database error",
+                "Failed to connect to database",
+            )));
         }
     };
 
@@ -265,14 +293,18 @@ pub async fn get_user_access_overview(
             granted_at,
             is_permanent
         FROM public.get_wallet_permissions_detailed_working($1)
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .load::<PermissionDetailRow>(&mut conn)
     .await
     .map_err(|e| {
         error!("Database error fetching detailed permissions: {}", e);
-        Json(UnifiedApiResponse::error(500, "Database error", "Failed to fetch permissions"))
+        Json(UnifiedApiResponse::error(
+            500,
+            "Database error",
+            "Failed to fetch permissions",
+        ))
     })?;
 
     // Process results
@@ -293,15 +325,29 @@ pub async fn get_user_access_overview(
 
     for row in rows {
         if row.source_type == "plan" {
-            let key = row.source_id.clone().unwrap_or_else(|| row.source_name.clone().unwrap_or("Unknown Plan".to_string()));
+            let key = row.source_id.clone().unwrap_or_else(|| {
+                row.source_name
+                    .clone()
+                    .unwrap_or("Unknown Plan".to_string())
+            });
             let days_remaining = calculate_days_remaining(row.expires_at);
-            let is_plan = row.source_name.as_ref().map(|n| 
-                n.contains("Plan") || n.contains("Starter") || n.contains("Pro") || n.contains("Enterprise")
-            ).unwrap_or(false);
-            
+            let is_plan = row
+                .source_name
+                .as_ref()
+                .map(|n| {
+                    n.contains("Plan")
+                        || n.contains("Starter")
+                        || n.contains("Pro")
+                        || n.contains("Enterprise")
+                })
+                .unwrap_or(false);
+
             let entry = plans_map.entry(key.clone()).or_insert(AccessPlanData {
                 id: key.clone(),
-                name: row.source_name.clone().unwrap_or("Unknown Plan".to_string()),
+                name: row
+                    .source_name
+                    .clone()
+                    .unwrap_or("Unknown Plan".to_string()),
                 description: None,
                 expires_at: row.expires_at.map(|d| d.to_rfc3339()),
                 permissions: Vec::new(),
@@ -314,7 +360,7 @@ pub async fn get_user_access_overview(
                 billing_cycle: None,
                 tier_level: 0, // Will be updated from direct query
             });
-            
+
             // Don't duplicate permissions
             if !entry.permissions.contains(&row.permission_string) {
                 entry.permissions.push(row.permission_string);
@@ -328,7 +374,11 @@ pub async fn get_user_access_overview(
                 days_remaining,
                 granted_at: Some(row.granted_at.to_rfc3339()),
                 granted_by: None, // Would require additional query
-                source: if row.is_permanent { "system".to_string() } else { "manual".to_string() },
+                source: if row.is_permanent {
+                    "system".to_string()
+                } else {
+                    "manual".to_string()
+                },
             });
         }
     }
@@ -367,7 +417,7 @@ pub async fn get_user_access_overview(
           AND pl.is_active = true
           AND (wpa.expires_at IS NULL OR wpa.expires_at > NOW())
         ORDER BY pl.tier_level DESC
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .load(&mut conn)
@@ -380,21 +430,24 @@ pub async fn get_user_access_overview(
             existing.tier_level = ap.tier_level;
         } else {
             let days_remaining = calculate_days_remaining(ap.expires_at);
-            plans_map.insert(ap.plan_id.clone(), AccessPlanData {
-                id: ap.plan_id.clone(),
-                name: ap.plan_name.clone(),
-                description: ap.description.clone(),
-                expires_at: ap.expires_at.map(|d| d.to_rfc3339()),
-                permissions: Vec::new(),
-                source_type: "plan".to_string(),
-                assigned_at: Some(ap.assigned_at.to_rfc3339()),
-                assigned_by: None,
-                days_remaining,
-                can_renew: days_remaining.map(|d| d <= 30).unwrap_or(true),
-                renewal_price: ap.price.as_ref().map(|p| p.to_string()),
-                billing_cycle: ap.billing_cycle.clone(),
-                tier_level: ap.tier_level,
-            });
+            plans_map.insert(
+                ap.plan_id.clone(),
+                AccessPlanData {
+                    id: ap.plan_id.clone(),
+                    name: ap.plan_name.clone(),
+                    description: ap.description.clone(),
+                    expires_at: ap.expires_at.map(|d| d.to_rfc3339()),
+                    permissions: Vec::new(),
+                    source_type: "plan".to_string(),
+                    assigned_at: Some(ap.assigned_at.to_rfc3339()),
+                    assigned_by: None,
+                    days_remaining,
+                    can_renew: days_remaining.map(|d| d <= 30).unwrap_or(true),
+                    renewal_price: ap.price.as_ref().map(|p| p.to_string()),
+                    billing_cycle: ap.billing_cycle.clone(),
+                    tier_level: ap.tier_level,
+                },
+            );
         }
     }
 
@@ -410,7 +463,8 @@ pub async fn get_user_access_overview(
     plans.sort_by(|a, b| b.tier_level.cmp(&a.tier_level));
 
     // Current tier = highest tier plan (first after sorting)
-    let current_tier = plans.iter()
+    let current_tier = plans
+        .iter()
         .find(|p| p.name != "Free")
         .map(|p| p.name.clone())
         .unwrap_or("Free User".to_string());
@@ -429,16 +483,21 @@ pub async fn get_user_access_overview(
 /// This is ALWAYS returned to users as a baseline plan with default permissions
 /// Centralized definition effectively acting as a constant
 fn get_free_plan() -> AccessPlanData {
-    use crate::core::constants::{FREE_PLAN_NAME, FREE_PLAN_DESCRIPTION, FREE_PLAN_DEFAULT_PERMISSIONS};
-    
+    use crate::core::constants::{
+        FREE_PLAN_DEFAULT_PERMISSIONS, FREE_PLAN_DESCRIPTION, FREE_PLAN_NAME,
+    };
+
     AccessPlanData {
         id: "free-plan".to_string(), // Fixed ID for the Free plan
         name: FREE_PLAN_NAME.to_string(),
         description: Some(FREE_PLAN_DESCRIPTION.to_string()),
         source_type: "plan".to_string(), // Frontend expects 'plan' for badge logic
-        permissions: FREE_PLAN_DEFAULT_PERMISSIONS.iter().map(|s| s.to_string()).collect(),
+        permissions: FREE_PLAN_DEFAULT_PERMISSIONS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
         expires_at: None,
-        assigned_at: None, 
+        assigned_at: None,
         assigned_by: Some("system".to_string()),
         days_remaining: None,
         can_renew: false,
@@ -473,7 +532,11 @@ pub async fn get_user_permissions(
     // Extract user context from validated Bearer token
     let user_context = match require_user_context(&request) {
         Ok(context) => context,
-        Err(_) => return Err(Json(UnifiedApiResponse::auth_error("Valid Bearer token required"))),
+        Err(_) => {
+            return Err(Json(UnifiedApiResponse::auth_error(
+                "Valid Bearer token required",
+            )))
+        }
     };
 
     // Check if user can view their own permissions
@@ -483,7 +546,9 @@ pub async fn get_user_permissions(
             "Permission denied for user {} to view permissions",
             user_context.wallet_address
         );
-        return Err(Json(UnifiedApiResponse::permission_error("epsx:user:view_permissions")));
+        return Err(Json(UnifiedApiResponse::permission_error(
+            "epsx:user:view_permissions",
+        )));
     }
 
     info!(
@@ -499,7 +564,9 @@ pub async fn get_user_permissions(
             Err(_) => {
                 return Ok(Json(UnifiedApiResponse::success_with_meta(
                     user_context.permissions.clone(),
-                    ResponseMeta::default().with_permissions(PermissionContext::from_permissions(&user_context.permissions)),
+                    ResponseMeta::default().with_permissions(PermissionContext::from_permissions(
+                        &user_context.permissions,
+                    )),
                 )));
             }
         };
@@ -516,7 +583,7 @@ pub async fn get_user_permissions(
             FROM user_effective_permissions
             WHERE wallet_address = $1
             ORDER BY permission_string
-            "#
+            "#,
         )
         .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
         .load::<PermissionRow>(&mut conn)
@@ -579,7 +646,9 @@ pub async fn update_user_preferences(
     );
 
     // Validate request
-    if update_request.notification_preferences.is_none() && update_request.display_preferences.is_none() {
+    if update_request.notification_preferences.is_none()
+        && update_request.display_preferences.is_none()
+    {
         return Err(Json(UnifiedApiResponse::validation_error(json!({
             "message": "At least one preference type must be provided"
         }))));
@@ -618,7 +687,7 @@ pub async fn update_user_preferences(
         ),
         updated_at = NOW()
         WHERE wallet_address = $1
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .bind::<diesel::sql_types::Jsonb, _>(&preferences_json)
@@ -627,7 +696,10 @@ pub async fn update_user_preferences(
 
     // Check if update succeeded
     if update_result.is_err() {
-        error!("Failed to update preferences for user: {}", user_context.wallet_address);
+        error!(
+            "Failed to update preferences for user: {}",
+            user_context.wallet_address
+        );
         return Err(Json(UnifiedApiResponse::error(
             500,
             "Database error",
@@ -678,7 +750,11 @@ pub async fn get_user_by_wallet_address(
     // Extract user context from validated Bearer token
     let user_context = match require_user_context(&request) {
         Ok(context) => context,
-        Err(_) => return Err(Json(UnifiedApiResponse::auth_error("Valid Bearer token required"))),
+        Err(_) => {
+            return Err(Json(UnifiedApiResponse::auth_error(
+                "Valid Bearer token required",
+            )))
+        }
     };
 
     // Check admin permission
@@ -687,7 +763,9 @@ pub async fn get_user_by_wallet_address(
             "Permission denied for user {} to view user data",
             user_context.wallet_address
         );
-        return Err(Json(UnifiedApiResponse::permission_error("admin:users:view")));
+        return Err(Json(UnifiedApiResponse::permission_error(
+            "admin:users:view",
+        )));
     }
 
     info!(
@@ -700,7 +778,11 @@ pub async fn get_user_by_wallet_address(
         Ok(c) => c,
         Err(e) => {
             error!("Failed to get database connection: {}", e);
-            return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to get database connection")));
+            return Err(Json(UnifiedApiResponse::error(
+                500,
+                "Database error",
+                "Failed to get database connection",
+            )));
         }
     };
 
@@ -726,14 +808,26 @@ pub async fn get_user_by_wallet_address(
 
     // Check if user exists
     let (wallet_addr, _is_active, created_at, last_auth) = match user_data {
-        Ok(Some(data)) => (data.wallet_address, data.is_active, data.created_at, data.last_auth_at),
+        Ok(Some(data)) => (
+            data.wallet_address,
+            data.is_active,
+            data.created_at,
+            data.last_auth_at,
+        ),
         Ok(None) => {
             error!("User not found: {}", wallet_address);
-            return Err(Json(UnifiedApiResponse::not_found(&format!("User {} not found", wallet_address))));
-        },
+            return Err(Json(UnifiedApiResponse::not_found(&format!(
+                "User {} not found",
+                wallet_address
+            ))));
+        }
         Err(e) => {
             error!("Database error looking up user {}: {}", wallet_address, e);
-            return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to query user")));
+            return Err(Json(UnifiedApiResponse::error(
+                500,
+                "Database error",
+                "Failed to query user",
+            )));
         }
     };
 
@@ -750,7 +844,7 @@ pub async fn get_user_by_wallet_address(
         FROM user_effective_permissions
         WHERE wallet_address = $1
           AND (expires_at IS NULL OR expires_at > NOW())
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&wallet_addr)
     .load::<UserPermissionRow>(&mut conn)
@@ -813,14 +907,19 @@ pub struct NotificationPreferencesResponse {
 pub async fn get_user_notification_preferences(
     State(_app_state): State<AppState>,
     Extension(user_context): Extension<OpenIDUserContext>,
-) -> Result<Json<UnifiedApiResponse<NotificationPreferencesResponse>>, Json<UnifiedApiResponse<()>>> {
+) -> Result<Json<UnifiedApiResponse<NotificationPreferencesResponse>>, Json<UnifiedApiResponse<()>>>
+{
     // User context already validated by middleware
 
     let mut conn = match _app_state.db_pool.get().await {
         Ok(c) => c,
         Err(e) => {
             error!("Failed to get database connection: {}", e);
-            return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to connect to database")));
+            return Err(Json(UnifiedApiResponse::error(
+                500,
+                "Database error",
+                "Failed to connect to database",
+            )));
         }
     };
 
@@ -830,18 +929,20 @@ pub async fn get_user_notification_preferences(
         wallet_metadata: Option<serde_json::Value>,
     }
 
-    let result = diesel::sql_query(
-        "SELECT wallet_metadata FROM wallet_users WHERE wallet_address = $1"
-    )
-    .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
-    .get_result::<MetadataRow>(&mut conn)
-    .await
-    .optional();
+    let result =
+        diesel::sql_query("SELECT wallet_metadata FROM wallet_users WHERE wallet_address = $1")
+            .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
+            .get_result::<MetadataRow>(&mut conn)
+            .await
+            .optional();
 
     let preferences = match result {
         Ok(Some(row)) => {
             if let Some(metadata) = row.wallet_metadata {
-                if let Some(prefs) = metadata.get("preferences").and_then(|p| p.get("notification_preferences")) {
+                if let Some(prefs) = metadata
+                    .get("preferences")
+                    .and_then(|p| p.get("notification_preferences"))
+                {
                     serde_json::from_value(prefs.clone()).unwrap_or_default()
                 } else {
                     NotificationPreferences::default()
@@ -849,13 +950,13 @@ pub async fn get_user_notification_preferences(
             } else {
                 NotificationPreferences::default()
             }
-        },
+        }
         _ => NotificationPreferences::default(),
     };
 
-    Ok(Json(UnifiedApiResponse::success(NotificationPreferencesResponse {
-        preferences,
-    })))
+    Ok(Json(UnifiedApiResponse::success(
+        NotificationPreferencesResponse { preferences },
+    )))
 }
 
 /// Dashboard init: returns plan access + watchlist in one call
@@ -874,7 +975,7 @@ pub async fn dashboard_init_handler(
 
     Json(UnifiedApiResponse::success(json!({
         "plan_access": plan_access.unwrap_or(json!(null)),
-        "watchlist": watchlist.unwrap_or(json!([])),
+        "watchlist": watchlist.unwrap_or_default(),
     })))
 }
 
@@ -895,7 +996,7 @@ async fn fetch_user_plan_access(app_state: &AppState, wallet: &str) -> Result<Va
         "SELECT wpa.plan_id::text, p.name as plan_name, wpa.expires_at
          FROM wallet_plan_assignments wpa
          INNER JOIN plans p ON wpa.plan_id = p.id
-         WHERE wpa.wallet_address = $1 AND wpa.is_active = true"
+         WHERE wpa.wallet_address = $1 AND wpa.is_active = true",
     )
     .bind::<diesel::sql_types::Text, _>(wallet)
     .load::<PlanRow>(&mut conn)
@@ -905,25 +1006,98 @@ async fn fetch_user_plan_access(app_state: &AppState, wallet: &str) -> Result<Va
     Ok(serde_json::to_value(results).unwrap_or_else(|_| json!([])))
 }
 
-async fn fetch_user_watchlist(app_state: &AppState, wallet: &str) -> Result<Value, String> {
+fn normalize_watchlist_symbol(symbol: &str) -> String {
+    symbol
+        .trim()
+        .split(':')
+        .next_back()
+        .unwrap_or(symbol)
+        .to_uppercase()
+}
+
+async fn fetch_user_watchlist(app_state: &AppState, wallet: &str) -> Result<Vec<String>, String> {
     let mut conn = app_state.db_pool.get().await.map_err(|e| e.to_string())?;
 
     #[derive(QueryableByName)]
     struct WatchlistRow {
         #[diesel(sql_type = diesel::sql_types::Text)]
-        ticker: String,
+        symbol: String,
     }
 
     let results = diesel::sql_query(
-        "SELECT ticker FROM user_watchlist WHERE wallet_address = $1 ORDER BY added_at DESC"
+        "SELECT symbol FROM user_watchlist WHERE wallet_address = $1 ORDER BY added_at DESC",
     )
     .bind::<diesel::sql_types::Text, _>(wallet)
     .load::<WatchlistRow>(&mut conn)
     .await
     .map_err(|e| e.to_string())?;
 
-    Ok(serde_json::to_value(results.into_iter().map(|r| r.ticker).collect::<Vec<_>>())
-        .unwrap_or_else(|_| json!([])))
+    Ok(results
+        .into_iter()
+        .map(|row| normalize_watchlist_symbol(&row.symbol))
+        .filter(|symbol| !symbol.is_empty())
+        .collect())
+}
+
+async fn fetch_portfolio_rankings(watchlist: &[String]) -> Result<Vec<SymbolCardData>, String> {
+    let mut seen = HashSet::new();
+    let normalized_watchlist: Vec<String> = watchlist
+        .iter()
+        .map(|symbol| normalize_watchlist_symbol(symbol))
+        .filter(|symbol| !symbol.is_empty())
+        .filter(|symbol| seen.insert(symbol.clone()))
+        .collect();
+
+    let tradingview_service =
+        TradingViewApiService::new(Arc::new(crate::config::get_fallback_config()));
+
+    let (screening_results, _) = tradingview_service
+        .fetch_eps_growth_ranking(
+            Some(0),
+            Some(1000),
+            None,
+            None,
+            Some("qoq_growth".to_string()),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut ranked_symbols = HashSet::new();
+    let mut cards = Vec::with_capacity(screening_results.len());
+
+    for (index, result) in screening_results.into_iter().enumerate() {
+        ranked_symbols.insert(normalize_watchlist_symbol(&result.symbol));
+        let ranking = convert_screening_result_to_eps_ranking(result);
+        let position = index + 1;
+        let unified = transform_ranking_to_unified_format(ranking, position);
+        let card = transform_unified_to_card_format(&unified);
+        cards.push(card);
+    }
+
+    let missing_watchlist_symbols: Vec<String> = normalized_watchlist
+        .into_iter()
+        .filter(|symbol| !ranked_symbols.contains(symbol))
+        .collect();
+
+    if !missing_watchlist_symbols.is_empty() {
+        let eps_data = tradingview_service
+            .fetch_symbols_concurrent(missing_watchlist_symbols)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        for data in eps_data {
+            let symbol = normalize_watchlist_symbol(&data.symbol);
+            if !ranked_symbols.insert(symbol) {
+                continue;
+            }
+            let ranking = EPSRanking::from_eps_data(data, None);
+            let unified = transform_ranking_to_unified_format(ranking, 0);
+            let card = transform_unified_to_card_format(&unified);
+            cards.push(card);
+        }
+    }
+
+    Ok(cards)
 }
 
 /// Portfolio overview: returns watchlist + analytics data
@@ -932,15 +1106,28 @@ pub async fn portfolio_overview_handler(
     State(app_state): State<AppState>,
     Extension(ctx): Extension<OpenIDUserContext>,
 ) -> impl axum::response::IntoResponse {
-    info!("User: Getting portfolio overview for {}", ctx.wallet_address);
+    info!(
+        "User: Getting portfolio overview for {}",
+        ctx.wallet_address
+    );
     let wallet = ctx.wallet_address.to_lowercase();
 
-    let watchlist = fetch_user_watchlist(&app_state, &wallet).await
-        .unwrap_or_else(|_| json!([]));
+    let watchlist = fetch_user_watchlist(&app_state, &wallet)
+        .await
+        .unwrap_or_else(|e| {
+            warn!("Failed to fetch watchlist for {}: {}", wallet, e);
+            Vec::new()
+        });
+    let rankings = fetch_portfolio_rankings(&watchlist)
+        .await
+        .unwrap_or_else(|e| {
+            warn!("Failed to fetch portfolio rankings for {}: {}", wallet, e);
+            Vec::new()
+        });
 
     Json(UnifiedApiResponse::success(json!({
         "watchlist": watchlist,
-        "rankings": [],
+        "rankings": rankings,
     })))
 }
 
@@ -963,14 +1150,19 @@ pub async fn update_user_notification_preferences(
     State(_app_state): State<AppState>,
     Extension(user_context): Extension<OpenIDUserContext>,
     Json(preferences): Json<NotificationPreferences>,
-) -> Result<Json<UnifiedApiResponse<NotificationPreferencesResponse>>, Json<UnifiedApiResponse<()>>> {
+) -> Result<Json<UnifiedApiResponse<NotificationPreferencesResponse>>, Json<UnifiedApiResponse<()>>>
+{
     // User context already validated by middleware
 
     let mut conn = match _app_state.db_pool.get().await {
         Ok(c) => c,
         Err(e) => {
             error!("Failed to get database connection: {}", e);
-            return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to connect to database")));
+            return Err(Json(UnifiedApiResponse::error(
+                500,
+                "Database error",
+                "Failed to connect to database",
+            )));
         }
     };
 
@@ -982,7 +1174,7 @@ pub async fn update_user_notification_preferences(
 
     // We can do a deep merge or just ensure the path exists.
     // For simplicity, let's use a specialized query to ensure structure.
-    
+
     // First ensure 'preferences' object exists
     let _ = diesel::sql_query(
         r#"
@@ -994,7 +1186,7 @@ pub async fn update_user_notification_preferences(
             true
         )
         WHERE wallet_address = $1
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .execute(&mut conn)
@@ -1012,7 +1204,7 @@ pub async fn update_user_notification_preferences(
         ),
         updated_at = NOW()
         WHERE wallet_address = $1
-        "#
+        "#,
     )
     .bind::<diesel::sql_types::Text, _>(&user_context.wallet_address)
     .bind::<diesel::sql_types::Jsonb, _>(serde_json::to_value(&preferences).unwrap_or_default())
@@ -1020,10 +1212,14 @@ pub async fn update_user_notification_preferences(
     .await;
 
     if update_result.is_err() {
-        return Err(Json(UnifiedApiResponse::error(500, "Database error", "Failed to update preferences")));
+        return Err(Json(UnifiedApiResponse::error(
+            500,
+            "Database error",
+            "Failed to update preferences",
+        )));
     }
 
-    Ok(Json(UnifiedApiResponse::success(NotificationPreferencesResponse {
-        preferences,
-    })))
+    Ok(Json(UnifiedApiResponse::success(
+        NotificationPreferencesResponse { preferences },
+    )))
 }

--- a/apps/frontend/app/actions/watchlist.ts
+++ b/apps/frontend/app/actions/watchlist.ts
@@ -6,10 +6,16 @@ import { getServerActionClient } from '@/shared/utils/server-fetch';
 import { revalidatePath } from 'next/cache';
 import type { SymbolCardData } from '@/shared/types/analytics';
 
-export async function getPortfolioOverviewAction(): Promise<{ watchlist: string[]; rankings: SymbolCardData[] }> {
+export async function getPortfolioOverviewAction(): Promise<{
+  watchlist: string[];
+  rankings: SymbolCardData[];
+}> {
   try {
     const client = getServerActionClient();
-    const res = await client.get<{ watchlist: string[]; rankings: SymbolCardData[] }>('/api/users/portfolio/overview');
+    const res = await client.get<{
+      watchlist: string[];
+      rankings: SymbolCardData[];
+    }>('/api/users/portfolio/overview');
     if (res.success && res.data) {
       return res.data;
     }
@@ -35,12 +41,15 @@ export async function getWatchlistAction(): Promise<string[]> {
   return [];
 }
 
-export async function addToWatchlistAction(symbol: string): Promise<string[] | null> {
+export async function addToWatchlistAction(
+  symbol: string
+): Promise<string[] | null> {
   try {
     const client = getServerActionClient();
     const api = createUsersClient(client);
     const res = await api.addToWatchlist(symbol);
     if (res.success && res.data) {
+      revalidatePath('/analytics');
       revalidatePath('/portfolio');
       return res.data.symbols;
     }
@@ -51,12 +60,15 @@ export async function addToWatchlistAction(symbol: string): Promise<string[] | n
   return null;
 }
 
-export async function removeFromWatchlistAction(symbol: string): Promise<string[] | null> {
+export async function removeFromWatchlistAction(
+  symbol: string
+): Promise<string[] | null> {
   try {
     const client = getServerActionClient();
     const api = createUsersClient(client);
     const res = await api.removeFromWatchlist(symbol);
     if (res.success && res.data) {
+      revalidatePath('/analytics');
       revalidatePath('/portfolio');
       return res.data.symbols;
     }

--- a/apps/frontend/components/portfolio/portfolio-grid.tsx
+++ b/apps/frontend/components/portfolio/portfolio-grid.tsx
@@ -11,13 +11,16 @@ interface PortfolioGridProps {
   allRankings: SymbolCardData[];
 }
 
-export function PortfolioGrid({ watchedStocks: initialWatched, allRankings }: PortfolioGridProps) {
+export function PortfolioGrid({
+  watchedStocks: initialWatched,
+  allRankings,
+}: PortfolioGridProps) {
   const { symbols, isWatchlisted, toggle, isLoading } = useWatchlist();
 
   // Re-derive watched stocks from current watchlist state
   const watchedStocks = useMemo(() => {
-    const set = new Set(symbols.map((s) => s.toUpperCase()));
-    return allRankings.filter((r) => set.has(r.symbol.toUpperCase()));
+    const set = new Set(symbols.map(s => s.toUpperCase()));
+    return allRankings.filter(r => set.has(r.symbol.toUpperCase()));
   }, [symbols, allRankings]);
 
   if (watchedStocks.length === 0) {
@@ -26,10 +29,12 @@ export function PortfolioGrid({ watchedStocks: initialWatched, allRankings }: Po
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gray-100 dark:bg-slate-800/50">
           <Heart className="h-8 w-8 text-slate-400" />
         </div>
-        <h3 className="mb-2 text-lg font-semibold text-foreground">No stocks in watchlist</h3>
+        <h3 className="text-foreground mb-2 text-lg font-semibold">
+          No stocks in watchlist
+        </h3>
         <p className="max-w-md text-center text-sm text-slate-400">
-          Use the search bar above to find stocks and add them to your watchlist.
-          Click the heart icon on any stock card to track it here.
+          Use the search bar above to find stocks and add them to your
+          watchlist. Click the heart icon on any stock card to track it here.
         </p>
       </div>
     );
@@ -38,10 +43,11 @@ export function PortfolioGrid({ watchedStocks: initialWatched, allRankings }: Po
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-foreground">
+        <h2 className="text-foreground text-lg font-semibold">
           Your Watchlist
           <span className="ml-2 text-sm font-normal text-slate-400">
-            ({watchedStocks.length} stock{watchedStocks.length !== 1 ? 's' : ''})
+            ({watchedStocks.length} stock{watchedStocks.length !== 1 ? 's' : ''}
+            )
           </span>
         </h2>
         {isLoading && (
@@ -50,7 +56,7 @@ export function PortfolioGrid({ watchedStocks: initialWatched, allRankings }: Po
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-        {watchedStocks.map((card) => {
+        {watchedStocks.map(card => {
           const latestQ = card.quarterly_performance[0];
           return (
             <StockDataCard
@@ -60,9 +66,11 @@ export function PortfolioGrid({ watchedStocks: initialWatched, allRankings }: Po
               epsGrowth={latestQ?.eps_growth ?? 0}
               price={latestQ?.price ?? 0}
               currency={card.currency}
-              daysUntilNextAction={card.next_quarter_estimate?.days_until_announcement ?? 0}
+              daysUntilNextAction={
+                card.next_quarter_estimate?.days_until_announcement ?? 0
+              }
               companyName={card.company_name ?? card.name}
-              variant={card.rank <= 5 ? 'premium' : 'standard'}
+              variant={card.rank > 0 && card.rank <= 5 ? 'premium' : 'standard'}
               isWatchlisted={true}
               onWatchlistToggle={toggle}
             />

--- a/apps/frontend/components/portfolio/stock-search.tsx
+++ b/apps/frontend/components/portfolio/stock-search.tsx
@@ -17,13 +17,15 @@ export function StockSearch({ rankings }: StockSearchProps) {
   const { isWatchlisted, toggle } = useWatchlist();
 
   const results = useMemo(() => {
-    if (query.length < 1) {return [];}
+    if (query.length < 1) {
+      return [];
+    }
     const q = query.toUpperCase();
     return rankings
       .filter(
-        (r) =>
+        r =>
           r.symbol.includes(q) ||
-          (r.company_name ?? r.name ?? '').toUpperCase().includes(q),
+          (r.company_name ?? r.name ?? '').toUpperCase().includes(q)
       )
       .slice(0, 12);
   }, [query, rankings]);
@@ -32,27 +34,33 @@ export function StockSearch({ rankings }: StockSearchProps) {
     (symbol: string) => {
       toggle(symbol);
     },
-    [toggle],
+    [toggle]
   );
 
   return (
     <div className="space-y-4">
       {/* Search bar */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+        <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
         <input
           type="text"
           placeholder="Search stocks to add to watchlist..."
           value={query}
-          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onChange={e => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
           onFocus={() => setOpen(true)}
-          className="w-full rounded-xl border border-gray-200 dark:border-slate-700 bg-gray-100 dark:bg-slate-800/50 py-3 pl-10 pr-10 text-sm text-foreground placeholder-slate-500 outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/30"
+          className="text-foreground w-full rounded-xl border border-gray-200 bg-gray-100 py-3 pr-10 pl-10 text-sm placeholder-slate-500 outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/30 dark:border-slate-700 dark:bg-slate-800/50"
         />
         {query.length > 0 && (
           <button
             type="button"
-            onClick={() => { setQuery(''); setOpen(false); }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white"
+            onClick={() => {
+              setQuery('');
+              setOpen(false);
+            }}
+            className="absolute top-1/2 right-3 -translate-y-1/2 text-slate-400 hover:text-white"
           >
             <X className="h-4 w-4" />
           </button>
@@ -62,7 +70,7 @@ export function StockSearch({ rankings }: StockSearchProps) {
       {/* Results */}
       {open && results.length > 0 && (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {results.map((r) => {
+          {results.map(r => {
             const latestQ = r.quarterly_performance[0];
             const watched = isWatchlisted(r.symbol);
             return (
@@ -73,9 +81,11 @@ export function StockSearch({ rankings }: StockSearchProps) {
                   epsGrowth={latestQ?.eps_growth ?? 0}
                   price={latestQ?.price ?? 0}
                   currency={r.currency}
-                  daysUntilNextAction={r.next_quarter_estimate?.days_until_announcement ?? 0}
+                  daysUntilNextAction={
+                    r.next_quarter_estimate?.days_until_announcement ?? 0
+                  }
                   companyName={r.company_name ?? r.name}
-                  variant={r.rank <= 5 ? 'premium' : 'standard'}
+                  variant={r.rank > 0 && r.rank <= 5 ? 'premium' : 'standard'}
                   isWatchlisted={watched}
                   onWatchlistToggle={handleToggle}
                 />

--- a/apps/frontend/components/portfolio/watchlist-provider.tsx
+++ b/apps/frontend/components/portfolio/watchlist-provider.tsx
@@ -1,8 +1,18 @@
 'use client';
 
-import { addToWatchlistAction, removeFromWatchlistAction } from '@/app/actions/watchlist';
+import {
+  addToWatchlistAction,
+  removeFromWatchlistAction,
+} from '@/app/actions/watchlist';
 import { useRequireAuth } from '@/shared/hooks/use-require-auth';
-import { createContext, useCallback, useContext, useMemo, useState, useTransition } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 
 interface WatchlistCtx {
   symbols: string[];
@@ -18,6 +28,14 @@ const Ctx = createContext<WatchlistCtx>({
   toggle: () => undefined,
 });
 
+function normalizeSymbol(symbol: string) {
+  return symbol.trim().toUpperCase();
+}
+
+function normalizeSymbols(symbols: string[]) {
+  return Array.from(new Set(symbols.map(normalizeSymbol).filter(Boolean)));
+}
+
 export function useWatchlist() {
   return useContext(Ctx);
 }
@@ -29,43 +47,66 @@ export function WatchlistProvider({
   initial: string[];
   children: React.ReactNode;
 }) {
-  const [symbols, setSymbols] = useState<string[]>(initial);
+  const [symbols, setSymbols] = useState<string[]>(() =>
+    normalizeSymbols(initial)
+  );
   const [isPending, startTransition] = useTransition();
   const { requireAuth } = useRequireAuth();
 
-  const symbolSet = useMemo(() => new Set(symbols), [symbols]);
-
-  const isWatchlisted = useCallback(
-    (s: string) => symbolSet.has(s.toUpperCase()),
-    [symbolSet],
+  const symbolSet = useMemo(
+    () => new Set(normalizeSymbols(symbols)),
+    [symbols]
   );
 
-  const doToggle = useCallback(async (upper: string, removing: boolean) => {
-    const ok = await requireAuth();
-    if (!ok) { return; }
-    if (removing) {
-      setSymbols((prev) => prev.filter((s) => s !== upper));
-    } else {
-      setSymbols((prev) => [...prev, upper]);
-    }
-    const updated = removing
-      ? await removeFromWatchlistAction(upper)
-      : await addToWatchlistAction(upper);
-    if (updated !== null) { setSymbols(updated); }
-  }, [requireAuth]);
+  const isWatchlisted = useCallback(
+    (s: string) => symbolSet.has(normalizeSymbol(s)),
+    [symbolSet]
+  );
+
+  const doToggle = useCallback(
+    async (upper: string, removing: boolean) => {
+      const ok = await requireAuth();
+      if (!ok) {
+        return;
+      }
+      if (removing) {
+        setSymbols(prev => normalizeSymbols(prev).filter(s => s !== upper));
+      } else {
+        setSymbols(prev => normalizeSymbols([...prev, upper]));
+      }
+      const updated = removing
+        ? await removeFromWatchlistAction(upper)
+        : await addToWatchlistAction(upper);
+      if (updated !== null) {
+        setSymbols(normalizeSymbols(updated));
+        return;
+      }
+      setSymbols(prev =>
+        removing
+          ? normalizeSymbols([...prev, upper])
+          : normalizeSymbols(prev).filter(s => s !== upper)
+      );
+    },
+    [requireAuth]
+  );
 
   const toggle = useCallback(
     (symbol: string) => {
-      const upper = symbol.toUpperCase();
+      const upper = normalizeSymbol(symbol);
+      if (!upper) {
+        return;
+      }
       const removing = symbolSet.has(upper);
-      startTransition(() => { void doToggle(upper, removing); });
+      startTransition(() => {
+        void doToggle(upper, removing);
+      });
     },
-    [symbolSet, doToggle],
+    [symbolSet, doToggle]
   );
 
   const value = useMemo(
     () => ({ symbols, isLoading: isPending, isWatchlisted, toggle }),
-    [symbols, isPending, isWatchlisted, toggle],
+    [symbols, isPending, isWatchlisted, toggle]
   );
 
   return <Ctx value={value}>{children}</Ctx>;

--- a/shared/components/cards/stock-data-card.tsx
+++ b/shared/components/cards/stock-data-card.tsx
@@ -1,4 +1,3 @@
-
 import { ArrowRight, Calendar, Heart, TrendingUp } from 'lucide-react';
 import { cn } from '../../utils';
 import { PremiumCard } from '../ui/premium-card';
@@ -38,12 +37,31 @@ const formatCurrency = (value: number, currency = 'USD'): string => {
   }).format(value);
 };
 
-const getRankTheme = (rank: number): { color: string; glow: 'blue' | 'purple' | 'orange' | 'green' | 'none', label: string } => {
-  if (rank === 1) { return { color: 'text-yellow-400', glow: 'orange', label: 'CHAMPION' }; }
-  if (rank === 2) { return { color: 'text-slate-300', glow: 'blue', label: 'ELITE' }; }
-  if (rank === 3) { return { color: 'text-amber-500', glow: 'orange', label: 'LEGEND' }; }
-  if (rank === 4) { return { color: 'text-emerald-400', glow: 'green', label: 'MASTER' }; }
-  if (rank === 5) { return { color: 'text-teal-400', glow: 'green', label: 'EXPERT' }; }
+const getRankTheme = (
+  rank: number
+): {
+  color: string;
+  glow: 'blue' | 'purple' | 'orange' | 'green' | 'none';
+  label: string;
+} => {
+  if (rank < 1) {
+    return { color: 'text-blue-500', glow: 'none', label: 'WATCHLIST' };
+  }
+  if (rank === 1) {
+    return { color: 'text-yellow-400', glow: 'orange', label: 'CHAMPION' };
+  }
+  if (rank === 2) {
+    return { color: 'text-slate-300', glow: 'blue', label: 'ELITE' };
+  }
+  if (rank === 3) {
+    return { color: 'text-amber-500', glow: 'orange', label: 'LEGEND' };
+  }
+  if (rank === 4) {
+    return { color: 'text-emerald-400', glow: 'green', label: 'MASTER' };
+  }
+  if (rank === 5) {
+    return { color: 'text-teal-400', glow: 'green', label: 'EXPERT' };
+  }
   return { color: 'text-blue-500', glow: 'none', label: `RANK #${rank}` };
 };
 
@@ -51,7 +69,11 @@ const getRankTheme = (rank: number): { color: string; glow: 'blue' | 'purple' | 
 // SUB-COMPONENTS
 // ============================================================================
 
-function WatchlistButton({ symbol, isWatchlisted, onWatchlistToggle }: {
+function WatchlistButton({
+  symbol,
+  isWatchlisted,
+  onWatchlistToggle,
+}: {
   symbol: string;
   isWatchlisted?: boolean;
   onWatchlistToggle: (symbol: string) => void;
@@ -59,11 +81,24 @@ function WatchlistButton({ symbol, isWatchlisted, onWatchlistToggle }: {
   return (
     <button
       type="button"
-      onClick={(e) => { e.preventDefault(); e.stopPropagation(); onWatchlistToggle(symbol); }}
+      onClick={e => {
+        e.preventDefault();
+        e.stopPropagation();
+        onWatchlistToggle(symbol);
+      }}
       className="absolute top-3 right-3 z-20 p-1.5 rounded-full transition-colors hover:bg-black/[0.05] dark:hover:bg-white/10"
-      aria-label={isWatchlisted === true ? 'Remove from watchlist' : 'Add to watchlist'}
+      aria-label={
+        isWatchlisted === true ? 'Remove from watchlist' : 'Add to watchlist'
+      }
     >
-      <Heart className={cn('w-4 h-4 transition-colors', isWatchlisted === true ? 'fill-pink-500 text-pink-500' : 'text-gray-400 hover:text-pink-400')} />
+      <Heart
+        className={cn(
+          'w-4 h-4 transition-colors',
+          isWatchlisted === true
+            ? 'fill-pink-500 text-pink-500'
+            : 'text-gray-400 hover:text-pink-400'
+        )}
+      />
     </button>
   );
 }
@@ -71,17 +106,28 @@ function WatchlistButton({ symbol, isWatchlisted, onWatchlistToggle }: {
 function RankBadge({ rank, label }: { rank: number; label: string }) {
   return (
     <div className="absolute top-3 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20">
-      <div className={cn(
-        "text-white text-[10px] font-bold px-4 py-1.5 rounded-full shadow-lg uppercase tracking-wider",
-        rank <= 3 ? "bg-gradient-to-r from-blue-600 to-cyan-500" : "bg-gradient-to-r from-emerald-600 to-teal-500"
-      )}>
+      <div
+        className={cn(
+          'text-white text-[10px] font-bold px-4 py-1.5 rounded-full shadow-lg uppercase tracking-wider',
+          rank <= 3
+            ? 'bg-gradient-to-r from-blue-600 to-cyan-500'
+            : 'bg-gradient-to-r from-emerald-600 to-teal-500'
+        )}
+      >
         {label}
       </div>
     </div>
   );
 }
 
-function CardHeader({ rank, rankTheme, symbol, companyName, price, currency }: {
+function CardHeader({
+  rank,
+  rankTheme,
+  symbol,
+  companyName,
+  price,
+  currency,
+}: {
   rank: number;
   rankTheme: ReturnType<typeof getRankTheme>;
   symbol: string;
@@ -95,7 +141,14 @@ function CardHeader({ rank, rankTheme, symbol, companyName, price, currency }: {
         {rank > 5 ? rankTheme.label : 'Stock Symbol'}
       </h3>
       <div className="flex items-center justify-center mb-0.5">
-        <span className={cn("text-4xl font-black tracking-tighter", rankTheme.color)}>{symbol}</span>
+        <span
+          className={cn(
+            'text-4xl font-black tracking-tighter',
+            rankTheme.color
+          )}
+        >
+          {symbol}
+        </span>
       </div>
       {companyName !== undefined && companyName !== '' && (
         <div className="text-xs font-medium text-gray-500 dark:text-gray-400 truncate max-w-[90%] mx-auto">
@@ -115,7 +168,12 @@ function GrowthBar({ epsGrowth }: { epsGrowth: number }) {
   return (
     <div className="h-1.5 w-full bg-gray-200 dark:bg-gray-700/50 rounded-full overflow-hidden">
       <div
-        className={cn('h-full rounded-full relative', isPositive ? 'bg-gradient-to-r from-green-500 to-emerald-400' : 'bg-gradient-to-r from-red-500 to-rose-400')}
+        className={cn(
+          'h-full rounded-full relative',
+          isPositive
+            ? 'bg-gradient-to-r from-green-500 to-emerald-400'
+            : 'bg-gradient-to-r from-red-500 to-rose-400'
+        )}
         style={{ width: `${width}%` }}
       >
         <div className="absolute inset-0 bg-white/20" />
@@ -124,10 +182,15 @@ function GrowthBar({ epsGrowth }: { epsGrowth: number }) {
   );
 }
 
-function NextActionMetric({ daysUntilNextAction }: { daysUntilNextAction?: number }) {
-  const progressWidth = daysUntilNextAction !== undefined
-    ? Math.max(5, Math.min(100, ((90 - daysUntilNextAction) / 90) * 100))
-    : 0;
+function NextActionMetric({
+  daysUntilNextAction,
+}: {
+  daysUntilNextAction?: number;
+}) {
+  const progressWidth =
+    daysUntilNextAction !== undefined
+      ? Math.max(5, Math.min(100, ((90 - daysUntilNextAction) / 90) * 100))
+      : 0;
   return (
     <div className="flex flex-col gap-2 p-3 rounded-xl bg-white/5 group/feature hover:bg-white/10 transition-colors">
       <div className="flex items-center justify-between mb-1">
@@ -135,14 +198,21 @@ function NextActionMetric({ daysUntilNextAction }: { daysUntilNextAction?: numbe
           <div className="p-1.5 rounded-md bg-blue-500/20 text-blue-400">
             <Calendar className="w-3.5 h-3.5" />
           </div>
-          <span className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wider">Next Action</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wider">
+            Next Action
+          </span>
         </div>
         <span className="font-bold text-sm text-gray-900 dark:text-white">
-          {daysUntilNextAction !== undefined ? `${daysUntilNextAction} Days` : 'N/A'}
+          {daysUntilNextAction !== undefined
+            ? `${daysUntilNextAction} Days`
+            : 'N/A'}
         </span>
       </div>
       <div className="h-1.5 w-full bg-gray-200 dark:bg-gray-700/50 rounded-full overflow-hidden">
-        <div className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full relative" style={{ width: `${progressWidth}%` }}>
+        <div
+          className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full relative"
+          style={{ width: `${progressWidth}%` }}
+        >
           <div className="absolute inset-0 bg-white/20" />
         </div>
       </div>
@@ -172,28 +242,63 @@ export const StockDataCard = ({
 
   return (
     <PremiumCard
-      variant='glass'
+      variant="glass"
       glowColor={rankTheme.glow}
-      className={cn('w-full hover:-translate-y-1 transition-transform', className)}
+      className={cn(
+        'w-full hover:-translate-y-1 transition-transform',
+        className
+      )}
     >
       {onWatchlistToggle !== undefined && (
-        <WatchlistButton symbol={symbol} isWatchlisted={isWatchlisted} onWatchlistToggle={onWatchlistToggle} />
+        <WatchlistButton
+          symbol={symbol}
+          isWatchlisted={isWatchlisted}
+          onWatchlistToggle={onWatchlistToggle}
+        />
       )}
-      {rank <= 5 && <RankBadge rank={rank} label={rankTheme.label} />}
+      {rank > 0 && rank <= 5 && (
+        <RankBadge rank={rank} label={rankTheme.label} />
+      )}
 
-      <div className={cn("p-5 flex flex-col h-full relative z-10", rank <= 5 ? "pt-8" : "pt-5")}>
-        <CardHeader rank={rank} rankTheme={rankTheme} symbol={symbol} companyName={companyName} price={price} currency={currency} />
+      <div
+        className={cn(
+          'p-5 flex flex-col h-full relative z-10',
+          rank > 0 && rank <= 5 ? 'pt-8' : 'pt-5'
+        )}
+      >
+        <CardHeader
+          rank={rank}
+          rankTheme={rankTheme}
+          symbol={symbol}
+          companyName={companyName}
+          price={price}
+          currency={currency}
+        />
 
         <div className="space-y-2 mb-4 flex-grow">
           <div className="flex flex-col gap-2 p-3 rounded-xl bg-white/5 hover:bg-white/10 transition-colors">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <div className={cn("p-1.5 rounded-md", isPositiveGrowth ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400")}>
+                <div
+                  className={cn(
+                    'p-1.5 rounded-md',
+                    isPositiveGrowth
+                      ? 'bg-green-500/20 text-green-400'
+                      : 'bg-red-500/20 text-red-400'
+                  )}
+                >
                   <TrendingUp className="w-4 h-4" />
                 </div>
-                <span className="text-sm text-gray-600 dark:text-gray-300 font-medium">Growth</span>
+                <span className="text-sm text-gray-600 dark:text-gray-300 font-medium">
+                  Growth
+                </span>
               </div>
-              <span className={cn("font-bold text-sm", isPositiveGrowth ? "text-green-400" : "text-red-400")}>
+              <span
+                className={cn(
+                  'font-bold text-sm',
+                  isPositiveGrowth ? 'text-green-400' : 'text-red-400'
+                )}
+              >
                 {formatPercentage(epsGrowth)}
               </span>
             </div>
@@ -203,7 +308,12 @@ export const StockDataCard = ({
         </div>
 
         <div className="mt-auto">
-          <a href={`https://www.tradingview.com/symbols/${symbol}`} target="_blank" rel="noopener noreferrer" className="block w-full">
+          <a
+            href={`https://www.tradingview.com/symbols/${symbol}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full"
+          >
             <button className="w-full py-3 rounded-xl font-bold text-sm transition-all duration-300 relative overflow-hidden bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:shadow-lg hover:shadow-blue-500/25 group">
               <span className="relative flex items-center justify-center gap-2">
                 View Details
@@ -222,9 +332,18 @@ export const StockDataCard = ({
 
 StockDataCard.displayName = 'stock-data-card';
 
-export const StockDataCardSkeleton = ({ className }: { className?: string }) => {
+export const StockDataCardSkeleton = ({
+  className,
+}: {
+  className?: string;
+}) => {
   return (
-    <div className={cn("relative rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 flex flex-col h-[350px] animate-pulse", className)}>
+    <div
+      className={cn(
+        'relative rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 flex flex-col h-[350px] animate-pulse',
+        className
+      )}
+    >
       <div className="h-4 w-24 bg-gray-200 dark:bg-gray-800 rounded mx-auto mb-6" />
       <div className="h-12 w-32 bg-gray-200 dark:bg-gray-800 rounded mx-auto mb-2" />
       <div className="h-4 w-20 bg-gray-200 dark:bg-gray-800 rounded mx-auto mb-8" />
@@ -236,8 +355,8 @@ export const StockDataCardSkeleton = ({ className }: { className?: string }) => 
 
       <div className="mt-auto h-12 bg-gray-200 dark:bg-gray-800 rounded-xl w-full" />
     </div>
-  )
-}
+  );
+};
 
 StockDataCardSkeleton.displayName = 'StockDataCardskeleton';
 


### PR DESCRIPTION
## Summary
- persist analytics favorite/watchlist changes per wallet and revalidate analytics/portfolio views
- return portfolio overview rankings for the saved wallet watchlist instead of an empty list
- normalize watchlist symbols and roll back optimistic UI state when persistence fails

## Verification
- cargo check --manifest-path apps/backend/Cargo.toml --features cli-tools --bin epsx --bin migrate
- bun run type-check --filter='epsx-frontend'
- bun run build:frontend
- ./infrastructure/scripts/build-backend-local.sh
- bunx prettier --check apps/frontend/app/actions/watchlist.ts apps/frontend/components/portfolio/watchlist-provider.tsx