### PR TITLE
fix: hydrate auth token after reload

### DIFF
--- a/shared/auth/actions.ts
+++ b/shared/auth/actions.ts
@@ -3,18 +3,24 @@
 import { cookies } from 'next/headers';
 import { logger } from '../utils/logger';
 import { getBackendUrl } from '../utils/url-resolver';
-import type { ChallengeResponse, SignatureVerificationRequest, SignatureVerificationResponse } from './api';
+import type {
+  ChallengeResponse,
+  SignatureVerificationRequest,
+  SignatureVerificationResponse,
+} from './api';
 import type { UserInfoResponse } from './client';
 import { COOKIES, COOKIE_OPTIONS, HTTP_ONLY_COOKIES } from './cookies';
 
-function sanitizeUserForClientCookie(user: UserInfoResponse | Record<string, unknown>): Record<string, unknown> {
-    const sanitized = { ...(user as Record<string, unknown>) };
-    delete sanitized.access;
-    delete sanitized.access_token;
-    delete sanitized.refresh_token;
-    delete sanitized.id_token;
-    delete sanitized.token;
-    return sanitized;
+function sanitizeUserForClientCookie(
+  user: UserInfoResponse | Record<string, unknown>
+): Record<string, unknown> {
+  const sanitized = { ...(user as Record<string, unknown>) };
+  delete sanitized.access;
+  delete sanitized.access_token;
+  delete sanitized.refresh_token;
+  delete sanitized.id_token;
+  delete sanitized.token;
+  return sanitized;
 }
 
 /**
@@ -22,329 +28,405 @@ function sanitizeUserForClientCookie(user: UserInfoResponse | Record<string, unk
  * This MUST be called from a Client Component or another Server Action.
  */
 export async function loginAction(
-    accessToken: string,
-    user: UserInfoResponse | Record<string, unknown>,
-    refreshToken?: string
+  accessToken: string,
+  user: UserInfoResponse | Record<string, unknown>,
+  refreshToken?: string
 ) {
-    try {
-        logger.info('[AUTH] loginAction called with:', {
-            hasAccessToken: Boolean(accessToken),
-            tokenLength: accessToken.length,
-            hasUser: Boolean(user),
-            hasRefreshToken: Boolean(refreshToken),
-            cookieName: COOKIES.access_token,
-            env: process.env.NODE_ENV,
-        });
+  try {
+    logger.info('[AUTH] loginAction called with:', {
+      hasAccessToken: Boolean(accessToken),
+      tokenLength: accessToken.length,
+      hasUser: Boolean(user),
+      hasRefreshToken: Boolean(refreshToken),
+      cookieName: COOKIES.access_token,
+      env: process.env.NODE_ENV,
+    });
 
-        if (accessToken === '') {
-            logger.error('[AUTH] Error: loginAction: Missing access_token');
-            return { success: false, error: 'Missing access_token' };
-        }
-
-        const cookieStore = await cookies();
-
-        // 1. Set Access Token (HttpOnly)
-        // Log equivalent set-cookie header params for debugging
-        logger.info('[AUTH] Setting access_token cookie:', {
-            name: COOKIES.access_token,
-            secure: COOKIE_OPTIONS.httpOnly.secure,
-            sameSite: COOKIE_OPTIONS.httpOnly.sameSite,
-            domain: COOKIE_OPTIONS.httpOnly.domain,
-            path: COOKIE_OPTIONS.httpOnly.path,
-        });
-
-        cookieStore.set(COOKIES.access_token, accessToken, {
-            ...COOKIE_OPTIONS.httpOnly,
-            maxAge: COOKIE_OPTIONS.maxAge.access_token,
-        });
-
-        // 2. Set User Data (Client Accessible - but set from server)
-        cookieStore.set(COOKIES.user, JSON.stringify(sanitizeUserForClientCookie(user)), {
-            ...COOKIE_OPTIONS.clientSide,
-            maxAge: COOKIE_OPTIONS.maxAge.user,
-        });
-
-        // 3. Set Refresh Token (HttpOnly) if available
-        if (refreshToken !== undefined && refreshToken !== '') {
-            cookieStore.set(COOKIES.refresh_token, refreshToken, {
-                ...COOKIE_OPTIONS.httpOnly,
-                maxAge: COOKIE_OPTIONS.maxAge.refresh_token,
-            });
-        }
-
-        // 4. Set Authentication Timestamp
-        cookieStore.set(COOKIES.auth_time, Date.now().toString(), {
-            ...COOKIE_OPTIONS.clientSide,
-            maxAge: COOKIE_OPTIONS.maxAge.auth_time,
-        });
-
-        // 5. Set expires_at timestamp
-        const expiresAt = Date.now() + (COOKIE_OPTIONS.maxAge.access_token * 1000);
-        cookieStore.set(COOKIES.expires_at, expiresAt.toString(), {
-            ...COOKIE_OPTIONS.clientSide,
-            maxAge: COOKIE_OPTIONS.maxAge.expires_at,
-        });
-
-        logger.info('[AUTH] loginAction: All cookies set successfully', {
-            accessToken: COOKIES.access_token,
-            user: COOKIES.user,
-            authTime: COOKIES.auth_time,
-            expiresAt: COOKIES.expires_at,
-        });
-
-        return { success: true };
-    } catch (error) {
-        logger.error('Login action failed:', error instanceof Error ? error.message : String(error));
-        return { success: false, error: 'Internal server error' };
+    if (accessToken === '') {
+      logger.error('[AUTH] Error: loginAction: Missing access_token');
+      return { success: false, error: 'Missing access_token' };
     }
+
+    const cookieStore = await cookies();
+
+    // 1. Set Access Token (HttpOnly)
+    // Log equivalent set-cookie header params for debugging
+    logger.info('[AUTH] Setting access_token cookie:', {
+      name: COOKIES.access_token,
+      secure: COOKIE_OPTIONS.httpOnly.secure,
+      sameSite: COOKIE_OPTIONS.httpOnly.sameSite,
+      domain: COOKIE_OPTIONS.httpOnly.domain,
+      path: COOKIE_OPTIONS.httpOnly.path,
+    });
+
+    cookieStore.set(COOKIES.access_token, accessToken, {
+      ...COOKIE_OPTIONS.httpOnly,
+      maxAge: COOKIE_OPTIONS.maxAge.access_token,
+    });
+
+    // 2. Set User Data (Client Accessible - but set from server)
+    cookieStore.set(
+      COOKIES.user,
+      JSON.stringify(sanitizeUserForClientCookie(user)),
+      {
+        ...COOKIE_OPTIONS.clientSide,
+        maxAge: COOKIE_OPTIONS.maxAge.user,
+      }
+    );
+
+    // 3. Set Refresh Token (HttpOnly) if available
+    if (refreshToken !== undefined && refreshToken !== '') {
+      cookieStore.set(COOKIES.refresh_token, refreshToken, {
+        ...COOKIE_OPTIONS.httpOnly,
+        maxAge: COOKIE_OPTIONS.maxAge.refresh_token,
+      });
+    }
+
+    // 4. Set Authentication Timestamp
+    cookieStore.set(COOKIES.auth_time, Date.now().toString(), {
+      ...COOKIE_OPTIONS.clientSide,
+      maxAge: COOKIE_OPTIONS.maxAge.auth_time,
+    });
+
+    // 5. Set expires_at timestamp
+    const expiresAt = Date.now() + COOKIE_OPTIONS.maxAge.access_token * 1000;
+    cookieStore.set(COOKIES.expires_at, expiresAt.toString(), {
+      ...COOKIE_OPTIONS.clientSide,
+      maxAge: COOKIE_OPTIONS.maxAge.expires_at,
+    });
+
+    logger.info('[AUTH] loginAction: All cookies set successfully', {
+      accessToken: COOKIES.access_token,
+      user: COOKIES.user,
+      authTime: COOKIES.auth_time,
+      expiresAt: COOKIES.expires_at,
+    });
+
+    return { success: true };
+  } catch (error) {
+    logger.error(
+      'Login action failed:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return { success: false, error: 'Internal server error' };
+  }
 }
 
 /**
  * Server Action to clear the user session.
  */
 export async function logoutAction() {
-    try {
-        const cookieStore = await cookies();
+  try {
+    const cookieStore = await cookies();
 
-        // Get wallet address before clearing cookies (best-effort, never block logout)
-        const userCookie = cookieStore.get(COOKIES.user)?.value;
-        let walletAddress = '';
-        if (userCookie !== undefined && userCookie !== '') {
-            try {
-                const decoded = decodeURIComponent(userCookie);
-                const user = JSON.parse(decoded) as UserInfoResponse;
-                walletAddress = user.wallet_address;
-            } catch {
-                // Cookie may be malformed (invalid encoding or JSON) — continue with logout
-            }
-        }
-
-        logger.info('[AUTH] logoutAction: Starting logout', { walletAddress: walletAddress.slice(0, 8) });
-
-        // Always attempt backend logout — even without wallet address, the backend
-        // can use the access token cookie or session to invalidate the session
-        try {
-            const { getBackendUrl: getBackendUrlFn } = await import('../utils/url-resolver');
-            const backendUrl = getBackendUrlFn('server');
-            const accessToken = cookieStore.get(COOKIES.access_token)?.value;
-
-            await fetch(`${backendUrl}/api/auth/web3/logout`, {
-                method: 'DELETE',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...(accessToken !== undefined && accessToken !== '' ? { Authorization: `Bearer ${accessToken}` } : {}),
-                },
-                body: JSON.stringify({ wallet_address: walletAddress }),
-                cache: 'no-store',
-            });
-
-            logger.info('[AUTH] logoutAction: Backend logout called');
-        } catch (e) {
-            // Best effort - continue clearing cookies even if backend call fails
-            logger.warn('[AUTH] logoutAction: Backend logout failed (continuing)',
-                e instanceof Error ? e.message : String(e));
-        }
-
-        // Clear all known cookies
-        // Use set(maxAge=0) instead of delete() — delete() omits the Secure flag,
-        // which prevents deletion of __Host- prefixed cookies (browser spec requires Secure).
-        const isProd = process.env.NODE_ENV === 'production';
-        Object.entries(COOKIES).forEach(([key, cookieName]) => {
-            const isHttpOnly = (HTTP_ONLY_COOKIES as readonly string[]).includes(key);
-            try {
-                cookieStore.set(cookieName, '', {
-                    maxAge: 0,
-                    httpOnly: isHttpOnly,
-                    secure: isProd,
-                    sameSite: 'lax',
-                    path: '/',
-                });
-            } catch { /* ignore individual cookie failures */ }
-        });
-
-        logger.info('[AUTH] logoutAction: All cookies cleared');
-        return { success: true };
-    } catch (error) {
-        logger.error('Logout action failed:', error instanceof Error ? error.message : String(error));
-        return { success: false, error: 'Internal server error' };
+    // Get wallet address before clearing cookies (best-effort, never block logout)
+    const userCookie = cookieStore.get(COOKIES.user)?.value;
+    let walletAddress = '';
+    if (userCookie !== undefined && userCookie !== '') {
+      try {
+        const decoded = decodeURIComponent(userCookie);
+        const user = JSON.parse(decoded) as UserInfoResponse;
+        walletAddress = user.wallet_address;
+      } catch {
+        // Cookie may be malformed (invalid encoding or JSON) — continue with logout
+      }
     }
+
+    logger.info('[AUTH] logoutAction: Starting logout', {
+      walletAddress: walletAddress.slice(0, 8),
+    });
+
+    // Always attempt backend logout — even without wallet address, the backend
+    // can use the access token cookie or session to invalidate the session
+    try {
+      const { getBackendUrl: getBackendUrlFn } =
+        await import('../utils/url-resolver');
+      const backendUrl = getBackendUrlFn('server');
+      const accessToken = cookieStore.get(COOKIES.access_token)?.value;
+
+      await fetch(`${backendUrl}/api/auth/web3/logout`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken !== undefined && accessToken !== ''
+            ? { Authorization: `Bearer ${accessToken}` }
+            : {}),
+        },
+        body: JSON.stringify({ wallet_address: walletAddress }),
+        cache: 'no-store',
+      });
+
+      logger.info('[AUTH] logoutAction: Backend logout called');
+    } catch (e) {
+      // Best effort - continue clearing cookies even if backend call fails
+      logger.warn(
+        '[AUTH] logoutAction: Backend logout failed (continuing)',
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+
+    // Clear all known cookies
+    // Use set(maxAge=0) instead of delete() — delete() omits the Secure flag,
+    // which prevents deletion of __Host- prefixed cookies (browser spec requires Secure).
+    const isProd = process.env.NODE_ENV === 'production';
+    Object.entries(COOKIES).forEach(([key, cookieName]) => {
+      const isHttpOnly = (HTTP_ONLY_COOKIES as readonly string[]).includes(key);
+      try {
+        cookieStore.set(cookieName, '', {
+          maxAge: 0,
+          httpOnly: isHttpOnly,
+          secure: isProd,
+          sameSite: 'lax',
+          path: '/',
+        });
+      } catch {
+        /* ignore individual cookie failures */
+      }
+    });
+
+    logger.info('[AUTH] logoutAction: All cookies cleared');
+    return { success: true };
+  } catch (error) {
+    logger.error(
+      'Logout action failed:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return { success: false, error: 'Internal server error' };
+  }
 }
 
 /**
  * Server Action to refresh the access token using the refresh token.
  * This eliminates the need for the /api/proxy route for token refresh.
  */
-export async function refreshSessionAction() {
-    try {
-        const cookieStore = await cookies();
-        const refreshToken = cookieStore.get(COOKIES.refresh_token)?.value;
+type RefreshSessionActionResult =
+  | { success: true; access_token: string; expires_in?: number }
+  | { success: false; error: string };
 
-        if (refreshToken === undefined || refreshToken === '') {
-            logger.warn('[AUTH] refreshSessionAction: No refresh token found');
-            return { success: false, error: 'No refresh token available' };
-        }
+export async function refreshSessionAction(): Promise<RefreshSessionActionResult> {
+  try {
+    const cookieStore = await cookies();
+    const refreshToken = cookieStore.get(COOKIES.refresh_token)?.value;
 
-        // Import dynamically to avoid bundling issues
-        const { getBackendUrl: getBackendUrlFn } = await import('../utils/url-resolver');
-        const backendUrl = getBackendUrlFn('server');
-
-        // Determine client_id from environment
-        const clientId = process.env.NEXT_PUBLIC_OAUTH_CLIENT_ID ?? 'epsx-frontend';
-
-        // Call backend refresh endpoint directly
-        const response = await fetch(`${backendUrl}/api/auth/session/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refresh_token: refreshToken, client_id: clientId }),
-            cache: 'no-store',
-        });
-
-        if (!response.ok) {
-            logger.error('[AUTH] refreshSessionAction: Backend refresh failed', String(response.status));
-            return { success: false, error: 'Token refresh failed' };
-        }
-
-        const data = (await response.json()) as {
-            access_token?: string;
-            expires_in?: number;
-            refresh_token?: string;
-            user?: Record<string, unknown>;
-        };
-
-        if (data.access_token === undefined || data.access_token === '') {
-            logger.error('[AUTH] refreshSessionAction: No access_token in response');
-            return { success: false, error: 'Invalid refresh response' };
-        }
-
-        updateSessionCookies(cookieStore, data);
-
-        logger.info('[AUTH] refreshSessionAction: Token refreshed successfully');
-        return { success: true, expires_in: data.expires_in };
-    } catch (error) {
-        logger.error('[AUTH] refreshSessionAction error:', error instanceof Error ? error.message : String(error));
-        return { success: false, error: 'Internal server error' };
+    if (refreshToken === undefined || refreshToken === '') {
+      logger.warn('[AUTH] refreshSessionAction: No refresh token found');
+      return { success: false, error: 'No refresh token available' };
     }
+
+    // Import dynamically to avoid bundling issues
+    const { getBackendUrl: getBackendUrlFn } =
+      await import('../utils/url-resolver');
+    const backendUrl = getBackendUrlFn('server');
+
+    // Determine client_id from environment
+    const clientId = process.env.NEXT_PUBLIC_OAUTH_CLIENT_ID ?? 'epsx-frontend';
+
+    // Call backend refresh endpoint directly
+    const response = await fetch(`${backendUrl}/api/auth/session/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+        client_id: clientId,
+      }),
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      logger.error(
+        '[AUTH] refreshSessionAction: Backend refresh failed',
+        String(response.status)
+      );
+      return { success: false, error: 'Token refresh failed' };
+    }
+
+    const data = (await response.json()) as {
+      access_token?: string;
+      expires_in?: number;
+      refresh_token?: string;
+      user?: Record<string, unknown>;
+    };
+
+    if (data.access_token === undefined || data.access_token === '') {
+      logger.error('[AUTH] refreshSessionAction: No access_token in response');
+      return { success: false, error: 'Invalid refresh response' };
+    }
+
+    updateSessionCookies(cookieStore, data);
+
+    logger.info('[AUTH] refreshSessionAction: Token refreshed successfully');
+    return {
+      success: true,
+      access_token: data.access_token,
+      expires_in: data.expires_in,
+    };
+  } catch (error) {
+    logger.error(
+      '[AUTH] refreshSessionAction error:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return { success: false, error: 'Internal server error' };
+  }
 }
 
 /**
  * Internal helper to update session cookies after token refresh
  */
 function updateSessionCookies(
-    cookieStore: Awaited<ReturnType<typeof cookies>>,
-    data: { access_token?: string; expires_in?: number; refresh_token?: string; user?: Record<string, unknown> }
+  cookieStore: Awaited<ReturnType<typeof cookies>>,
+  data: {
+    access_token?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    user?: Record<string, unknown>;
+  }
 ) {
-    if (data.access_token === undefined || data.access_token === '') { return; }
+  if (data.access_token === undefined || data.access_token === '') {
+    return;
+  }
 
-    const accessToken = data.access_token;
+  const accessToken = data.access_token;
 
-    // 1. Update Access Token
-    cookieStore.set(COOKIES.access_token, accessToken, {
-        ...COOKIE_OPTIONS.httpOnly,
-        maxAge: data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token,
+  // 1. Update Access Token
+  cookieStore.set(COOKIES.access_token, accessToken, {
+    ...COOKIE_OPTIONS.httpOnly,
+    maxAge: data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token,
+  });
+
+  // 2. Update Refresh Token if provided
+  if (data.refresh_token !== undefined && data.refresh_token !== '') {
+    cookieStore.set(COOKIES.refresh_token, data.refresh_token, {
+      ...COOKIE_OPTIONS.httpOnly,
+      maxAge: COOKIE_OPTIONS.maxAge.refresh_token,
     });
+  }
 
-    // 2. Update Refresh Token if provided
-    if (data.refresh_token !== undefined && data.refresh_token !== '') {
-        cookieStore.set(COOKIES.refresh_token, data.refresh_token, {
-            ...COOKIE_OPTIONS.httpOnly,
-            maxAge: COOKIE_OPTIONS.maxAge.refresh_token,
-        });
+  // 3. Update User Data
+  const existingUserCookie = cookieStore.get(COOKIES.user)?.value;
+  if (existingUserCookie !== undefined && existingUserCookie !== '') {
+    const existingUser = sanitizeUserForClientCookie(
+      JSON.parse(decodeURIComponent(existingUserCookie)) as Record<
+        string,
+        unknown
+      >
+    );
+    if (data.user) {
+      Object.assign(existingUser, sanitizeUserForClientCookie(data.user));
     }
 
-    // 3. Update User Data
-    const existingUserCookie = cookieStore.get(COOKIES.user)?.value;
-    if (existingUserCookie !== undefined && existingUserCookie !== '') {
-        const existingUser = sanitizeUserForClientCookie(JSON.parse(decodeURIComponent(existingUserCookie)) as Record<string, unknown>);
-        if (data.user) { Object.assign(existingUser, sanitizeUserForClientCookie(data.user)); }
-
-        cookieStore.set(COOKIES.user, JSON.stringify(existingUser), {
-            ...COOKIE_OPTIONS.clientSide,
-            maxAge: COOKIE_OPTIONS.maxAge.user,
-        });
-    } else if (data.user) {
-        cookieStore.set(COOKIES.user, JSON.stringify(sanitizeUserForClientCookie(data.user)), {
-            ...COOKIE_OPTIONS.clientSide,
-            maxAge: COOKIE_OPTIONS.maxAge.user,
-        });
-    }
-
-    // 4. Update expires_at
-    const expiresAt = Date.now() + ((data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token) * 1000);
-    cookieStore.set(COOKIES.expires_at, expiresAt.toString(), {
+    cookieStore.set(COOKIES.user, JSON.stringify(existingUser), {
+      ...COOKIE_OPTIONS.clientSide,
+      maxAge: COOKIE_OPTIONS.maxAge.user,
+    });
+  } else if (data.user) {
+    cookieStore.set(
+      COOKIES.user,
+      JSON.stringify(sanitizeUserForClientCookie(data.user)),
+      {
         ...COOKIE_OPTIONS.clientSide,
-        maxAge: COOKIE_OPTIONS.maxAge.expires_at,
-    });
+        maxAge: COOKIE_OPTIONS.maxAge.user,
+      }
+    );
+  }
+
+  // 4. Update expires_at
+  const expiresAt =
+    Date.now() + (data.expires_in ?? COOKIE_OPTIONS.maxAge.access_token) * 1000;
+  cookieStore.set(COOKIES.expires_at, expiresAt.toString(), {
+    ...COOKIE_OPTIONS.clientSide,
+    maxAge: COOKIE_OPTIONS.maxAge.expires_at,
+  });
 }
 
 /** Retry wrapper for network failures (5xx/network errors only, not client errors) */
-async function fetchWithRetry(url: string, init: RequestInit, retries = 2): Promise<Response> {
-    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
-    for (let i = 0; i <= retries; i++) {
-        try {
-            const res = await fetch(url, init);
-            // Don't retry client errors (4xx) - only server errors (5xx)
-            if (res.ok || res.status < 500) { return res; }
-            if (i < retries) { await delay(1000); }
-        } catch {
-            if (i === retries) { throw new Error('Network request failed. Please check your connection and try again.'); }
-            await delay(1000);
-        }
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  retries = 2
+): Promise<Response> {
+  const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const res = await fetch(url, init);
+      // Don't retry client errors (4xx) - only server errors (5xx)
+      if (res.ok || res.status < 500) {
+        return res;
+      }
+      if (i < retries) {
+        await delay(1000);
+      }
+    } catch {
+      if (i === retries) {
+        throw new Error(
+          'Network request failed. Please check your connection and try again.'
+        );
+      }
+      await delay(1000);
     }
-    throw new Error('Request failed after retries');
+  }
+  throw new Error('Request failed after retries');
 }
 
 /**
  * Server Action: Request SIWE challenge via server-to-server call.
  * Proxies through Next.js server so browser doesn't need direct backend access.
  */
-export async function challengeAction(walletAddress: string): Promise<ChallengeResponse> {
-    const url = `${getBackendUrl('server')}/api/auth/web3/challenge`;
+export async function challengeAction(
+  walletAddress: string
+): Promise<ChallengeResponse> {
+  const url = `${getBackendUrl('server')}/api/auth/web3/challenge`;
 
-    const body: Record<string, string> = { wallet_address: walletAddress };
+  const body: Record<string, string> = { wallet_address: walletAddress };
 
-    const res = await fetchWithRetry(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify(body),
-        cache: 'no-store',
-    });
+  const res = await fetchWithRetry(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
 
-    if (!res.ok) {
-        const err = (await res.json().catch(() => ({ error: 'Unknown error' }))) as { error?: string };
-        throw new Error(err.error ?? `Challenge failed: ${res.statusText}`);
-    }
+  if (!res.ok) {
+    const err = (await res
+      .json()
+      .catch(() => ({ error: 'Unknown error' }))) as { error?: string };
+    throw new Error(err.error ?? `Challenge failed: ${res.statusText}`);
+  }
 
-    const data = (await res.json()) as ChallengeResponse;
-    if (!data.success) {
-        throw new Error(data.error ?? 'Challenge generation failed');
-    }
+  const data = (await res.json()) as ChallengeResponse;
+  if (!data.success) {
+    throw new Error(data.error ?? 'Challenge generation failed');
+  }
 
-    return data;
+  return data;
 }
 
 /**
  * Server Action: Verify wallet signature via server-to-server call.
  * Proxies through Next.js server so browser doesn't need direct backend access.
  */
-export async function verifyAction(req: SignatureVerificationRequest): Promise<SignatureVerificationResponse> {
-    const url = `${getBackendUrl('server')}/api/auth/web3/verify`;
+export async function verifyAction(
+  req: SignatureVerificationRequest
+): Promise<SignatureVerificationResponse> {
+  const url = `${getBackendUrl('server')}/api/auth/web3/verify`;
 
-    const res = await fetchWithRetry(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify(req),
-        cache: 'no-store',
-    });
+  const res = await fetchWithRetry(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(req),
+    cache: 'no-store',
+  });
 
-    if (!res.ok) {
-        const err = (await res.json().catch(() => ({ error: 'Unknown error' }))) as { error?: string };
-        throw new Error(err.error ?? `Verification failed: ${res.statusText}`);
-    }
+  if (!res.ok) {
+    const err = (await res
+      .json()
+      .catch(() => ({ error: 'Unknown error' }))) as { error?: string };
+    throw new Error(err.error ?? `Verification failed: ${res.statusText}`);
+  }
 
-    const data = (await res.json()) as SignatureVerificationResponse;
-    if (!data.success) {
-        throw new Error(data.error ?? 'Signature verification failed');
-    }
+  const data = (await res.json()) as SignatureVerificationResponse;
+  if (!data.success) {
+    throw new Error(data.error ?? 'Signature verification failed');
+  }
 
-    return data;
+  return data;
 }

--- a/shared/components/auth/hooks/use-auth-initialization.ts
+++ b/shared/components/auth/hooks/use-auth-initialization.ts
@@ -1,153 +1,219 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { SharedWeb3AuthClient, UserInfoResponse } from '../../../auth/client';
+import type {
+  SharedWeb3AuthClient,
+  UserInfoResponse,
+} from '../../../auth/client';
 import { refreshSessionAction } from '../../../auth/actions';
 import { COOKIES } from '../../../auth/cookies';
+import { setSharedClientToken } from '../../../utils/api-client';
 import { logger } from '../../../utils/logger';
 
 function getExpiresAt(): number | null {
-    if (typeof document === 'undefined') { return null; }
-    const name = COOKIES.expires_at;
-    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // eslint-disable-next-line security/detect-non-literal-regexp
-    const match = document.cookie.match(new RegExp(`(?:^|; )${escaped}=([^;]*)`));
-    if (match === null) { return null; }
-    const val = parseInt(match[1] ?? '', 10);
-    return isNaN(val) ? null : val;
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const name = COOKIES.expires_at;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  const match = document.cookie.match(new RegExp(`(?:^|; )${escaped}=([^;]*)`));
+  if (match === null) {
+    return null;
+  }
+  const val = parseInt(match[1] ?? '', 10);
+  return isNaN(val) ? null : val;
 }
 
 interface UseAuthInitializationProps {
-    client: SharedWeb3AuthClient;
-    initialUser: UserInfoResponse | null;
-    clientId: string;
-    onAuthError?: (error: string) => void;
+  client: SharedWeb3AuthClient;
+  initialUser: UserInfoResponse | null;
+  clientId: string;
+  onAuthError?: (error: string) => void;
+}
+
+function hasAccessToken(
+  user: UserInfoResponse
+): user is UserInfoResponse & { access: string } {
+  return typeof user.access === 'string' && user.access !== '';
 }
 
 export function useAuthInitialization({
-    client,
-    initialUser,
-    clientId,
-    onAuthError,
+  client,
+  initialUser,
+  clientId,
+  onAuthError,
 }: UseAuthInitializationProps) {
-    const [user, setUser] = useState<UserInfoResponse | null>(initialUser);
-    const [isLoading, setIsLoading] = useState(initialUser === null);
-    const [error, setError] = useState<string | null>(null);
+  const [user, setUser] = useState<UserInfoResponse | null>(initialUser);
+  const [isLoading, setIsLoading] = useState(initialUser === null);
+  const [error, setError] = useState<string | null>(null);
 
-    useEffect(() => {
-        const initializeAuth = () => {
-            try {
-                setError(null);
+  useEffect(() => {
+    const initializeAuth = async () => {
+      try {
+        setError(null);
 
-                if (initialUser !== null) {
-                    logger.info('[AUTH] Provider: Hydrated from server state', {
-                        wallet: initialUser.wallet_address,
-                    });
-                    client.setCurrentUser(initialUser);
-                    setIsLoading(false);
-                    return;
-                }
+        if (initialUser !== null) {
+          let hydratedUser = initialUser;
 
-                setIsLoading(true);
-
-                // Try in-memory client state (no cookie reads)
-                if (typeof window !== 'undefined') {
-                    const clientUser = client.getCurrentUser();
-                    if (clientUser !== null && client.isAuthenticated()) {
-                        logger.info('[AUTH] Client has valid in-memory auth state');
-                        setUser(clientUser);
-                        setIsLoading(false);
-                        return;
-                    }
-                }
-
-                setIsLoading(false);
-            } catch (err) {
-                const errorMessage = err instanceof Error ? err.message : 'Failed to initialize authentication';
-                logger.error('Authentication initialization failed', { error: errorMessage });
-                setError(errorMessage);
-                onAuthError?.(errorMessage);
-            } finally {
-                setIsLoading(false);
+          if (!hasAccessToken(hydratedUser)) {
+            const refreshResult = await refreshSessionAction();
+            if (
+              refreshResult.success &&
+              refreshResult.access_token !== undefined &&
+              refreshResult.access_token !== ''
+            ) {
+              setSharedClientToken(refreshResult.access_token);
+              client.updateTokens(
+                refreshResult.access_token,
+                refreshResult.expires_in
+              );
+              hydratedUser = {
+                ...hydratedUser,
+                access: refreshResult.access_token,
+              };
             }
-        };
+          } else {
+            setSharedClientToken(hydratedUser.access);
+          }
 
-        const safetyTimeout = setTimeout(() => {
-            setIsLoading((prev) => {
-                if (prev) {
-                    logger.warn('[AUTH] Provider: Initialization took too long, forcing load completion');
-                    return false;
-                }
-                return prev;
-            });
-        }, 5000);
+          logger.info('[AUTH] Provider: Hydrated from server state', {
+            wallet: hydratedUser.wallet_address,
+            hasAccessToken: hasAccessToken(hydratedUser),
+          });
+          client.setCurrentUser(hydratedUser);
+          setUser(hydratedUser);
+          setIsLoading(false);
+          return;
+        }
 
-        initializeAuth();
+        setIsLoading(true);
 
-        const unsubscribe = client.subscribe((newUser) => {
-            setUser(newUser);
-            if (newUser !== null) {
-                logger.info('User state updated', { wallet_address: newUser.wallet_address });
-            } else {
-                logger.info('User logged out');
-            }
+        // Try in-memory client state (no cookie reads)
+        if (typeof window !== 'undefined') {
+          const clientUser = client.getCurrentUser();
+          if (clientUser !== null && client.isAuthenticated()) {
+            logger.info('[AUTH] Client has valid in-memory auth state');
+            setUser(clientUser);
+            setIsLoading(false);
+            return;
+          }
+        }
+
+        setIsLoading(false);
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error
+            ? err.message
+            : 'Failed to initialize authentication';
+        logger.error('Authentication initialization failed', {
+          error: errorMessage,
         });
-
-        return () => {
-            clearTimeout(safetyTimeout);
-            unsubscribe();
-        };
-    }, [client, onAuthError, initialUser, clientId]);
-
-    // Phase 4: Proactive token refresh - runs 5 min before expiry
-    const walletAddr = user?.wallet_address ?? null;
-    useEffect(() => {
-        if (walletAddr === null) { return; }
-
-        let timerId: ReturnType<typeof setTimeout> | undefined;
-
-        const doRefresh = async (): Promise<boolean> => {
-            const result = await refreshSessionAction();
-            if (result.success) {
-                const updated = await client.loadCurrentUser();
-                if (updated !== null) {
-                    setUser(updated);
-                }
-                return true;
-            }
-            return false;
-        };
-
-        const schedule = () => {
-            const expiresAt = getExpiresAt();
-            if (expiresAt === null) { return; }
-            const timeUntilExpiry = expiresAt - Date.now();
-            // Already expired or expiring within 5 min → refresh immediately (1s delay to avoid tight loop)
-            // Otherwise schedule 5 min before expiry
-            const delay = timeUntilExpiry <= 5 * 60 * 1000 ? 1_000 : timeUntilExpiry - 5 * 60 * 1000;
-            timerId = setTimeout(() => {
-                void (async () => {
-                    try {
-                        const ok = await doRefresh();
-                        if (ok) { schedule(); }
-                        // If refresh failed: stop rescheduling, user re-auths on next 401
-                    } catch {
-                        // Network error: stop rescheduling
-                    }
-                })();
-            }, delay);
-        };
-
-        schedule();
-        return () => { if (timerId !== undefined) { clearTimeout(timerId); } };
-    }, [walletAddr, client]);
-
-    return {
-        user,
-        setUser,
-        isLoading,
-        setIsLoading,
-        error,
-        setError,
+        setError(errorMessage);
+        onAuthError?.(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
     };
+
+    const safetyTimeout = setTimeout(() => {
+      setIsLoading(prev => {
+        if (prev) {
+          logger.warn(
+            '[AUTH] Provider: Initialization took too long, forcing load completion'
+          );
+          return false;
+        }
+        return prev;
+      });
+    }, 5000);
+
+    void initializeAuth();
+
+    const unsubscribe = client.subscribe(newUser => {
+      setUser(newUser);
+      if (newUser !== null) {
+        logger.info('User state updated', {
+          wallet_address: newUser.wallet_address,
+        });
+      } else {
+        logger.info('User logged out');
+      }
+    });
+
+    return () => {
+      clearTimeout(safetyTimeout);
+      unsubscribe();
+    };
+  }, [client, onAuthError, initialUser, clientId]);
+
+  // Phase 4: Proactive token refresh - runs 5 min before expiry
+  const walletAddr = user?.wallet_address ?? null;
+  useEffect(() => {
+    if (walletAddr === null) {
+      return;
+    }
+
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    const doRefresh = async (): Promise<boolean> => {
+      const result = await refreshSessionAction();
+      if (result.success) {
+        if (result.access_token !== undefined && result.access_token !== '') {
+          setSharedClientToken(result.access_token);
+          client.updateTokens(result.access_token, result.expires_in);
+        }
+
+        const updated = await client.loadCurrentUser();
+        if (updated !== null) {
+          setUser(updated);
+        }
+        return true;
+      }
+      return false;
+    };
+
+    const schedule = () => {
+      const expiresAt = getExpiresAt();
+      if (expiresAt === null) {
+        return;
+      }
+      const timeUntilExpiry = expiresAt - Date.now();
+      // Already expired or expiring within 5 min → refresh immediately (1s delay to avoid tight loop)
+      // Otherwise schedule 5 min before expiry
+      const delay =
+        timeUntilExpiry <= 5 * 60 * 1000
+          ? 1_000
+          : timeUntilExpiry - 5 * 60 * 1000;
+      timerId = setTimeout(() => {
+        void (async () => {
+          try {
+            const ok = await doRefresh();
+            if (ok) {
+              schedule();
+            }
+            // If refresh failed: stop rescheduling, user re-auths on next 401
+          } catch {
+            // Network error: stop rescheduling
+          }
+        })();
+      }, delay);
+    };
+
+    schedule();
+    return () => {
+      if (timerId !== undefined) {
+        clearTimeout(timerId);
+      }
+    };
+  }, [walletAddr, client]);
+
+  return {
+    user,
+    setUser,
+    isLoading,
+    setIsLoading,
+    error,
+    setError,
+  };
 }

--- a/shared/components/auth/hooks/use-session-actions.ts
+++ b/shared/components/auth/hooks/use-session-actions.ts
@@ -7,81 +7,91 @@ import { setSharedClientToken } from '../../../utils/api-client';
 import { logger } from '../../../utils/logger';
 
 interface UseSessionActionsProps {
-    client: SharedWeb3AuthClient;
-    clientId: string;
-    setError: (error: string | null) => void;
-    onAuthError?: (error: string) => void;
+  client: SharedWeb3AuthClient;
+  clientId: string;
+  setError: (error: string | null) => void;
+  onAuthError?: (error: string) => void;
 }
 
 export function useSessionActions({
-    client,
-    setError,
-    onAuthError,
+  client,
+  setError,
+  onAuthError,
 }: UseSessionActionsProps) {
+  const clearServerSession = useCallback(async () => {
+    try {
+      const result = await logoutAction();
+      if (result.success === false) {
+        logger.error(
+          '[AUTH] Error: Failed to clear server session:',
+          result.error
+        );
+      }
+    } catch (e: unknown) {
+      logger.error(
+        '[AUTH] Error: Failed to clear server session:',
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+  }, []);
 
-    const clearServerSession = useCallback(async () => {
-        try {
-            const result = await logoutAction();
-            if (result.success === false) {
-                logger.error('[AUTH] Error: Failed to clear server session:', result.error);
-            }
-        } catch (e: unknown) {
-            logger.error('[AUTH] Error: Failed to clear server session:', e instanceof Error ? e.message : String(e));
+  const logout = useCallback(async () => {
+    try {
+      setError(null);
+      logger.info('Logging out user');
+
+      await clearServerSession();
+      client.logout();
+      setSharedClientToken(undefined);
+      logger.info('Logout successful');
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Logout failed';
+      logger.error('Logout error', { error: errorMessage });
+      setError(errorMessage);
+      onAuthError?.(errorMessage);
+    }
+  }, [client, setError, onAuthError, clearServerSession]);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      setError(null);
+      await client.loadCurrentUser();
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to refresh user data';
+      setError(errorMessage);
+      onAuthError?.(errorMessage);
+      throw new Error(errorMessage, { cause: err });
+    }
+  }, [client, setError, onAuthError]);
+
+  const refreshSession = useCallback(async () => {
+    try {
+      // Use server action (can read HttpOnly refresh_token cookie)
+      const result = await refreshSessionAction();
+      if (result.success) {
+        if (result.access_token !== undefined && result.access_token !== '') {
+          client.updateTokens(result.access_token, result.expires_in);
+          setSharedClientToken(result.access_token);
         }
-    }, []);
+        await client.loadCurrentUser();
+        return true;
+      }
+      // Fallback to client-side refresh (for in-memory token)
+      const clientSuccess = await client.refreshTokens();
+      if (clientSuccess) {
+        await client.loadCurrentUser();
+      }
+      return clientSuccess;
+    } catch (err) {
+      logger.error('[AUTH] Error: Session refresh error', err);
+      return false;
+    }
+  }, [client]);
 
-    const logout = useCallback(async () => {
-        try {
-            setError(null);
-            logger.info('Logging out user');
-
-            await clearServerSession();
-            client.logout();
-            setSharedClientToken(undefined);
-            logger.info('Logout successful');
-        } catch (err: unknown) {
-            const errorMessage = err instanceof Error ? err.message : 'Logout failed';
-            logger.error('Logout error', { error: errorMessage });
-            setError(errorMessage);
-            onAuthError?.(errorMessage);
-        }
-    }, [client, setError, onAuthError, clearServerSession]);
-
-    const refreshUser = useCallback(async () => {
-        try {
-            setError(null);
-            await client.loadCurrentUser();
-        } catch (err) {
-            const errorMessage = err instanceof Error ? err.message : 'Failed to refresh user data';
-            setError(errorMessage);
-            onAuthError?.(errorMessage);
-            throw new Error(errorMessage, { cause: err });
-        }
-    }, [client, setError, onAuthError]);
-
-    const refreshSession = useCallback(async () => {
-        try {
-            // Use server action (can read HttpOnly refresh_token cookie)
-            const result = await refreshSessionAction();
-            if (result.success) {
-                await client.loadCurrentUser();
-                return true;
-            }
-            // Fallback to client-side refresh (for in-memory token)
-            const clientSuccess = await client.refreshTokens();
-            if (clientSuccess) {
-                await client.loadCurrentUser();
-            }
-            return clientSuccess;
-        } catch (err) {
-            logger.error('[AUTH] Error: Session refresh error', err);
-            return false;
-        }
-    }, [client]);
-
-    return {
-        logout,
-        refreshUser,
-        refreshSession,
-    };
+  return {
+    logout,
+    refreshUser,
+    refreshSession,
+  };
 }


### PR DESCRIPTION
## Summary
- return refreshed access tokens from the session refresh server action
- hydrate the shared browser API token after server-state auth initialization
- keep readable user cookies sanitized while preserving cross-origin API auth

## Verification
- rm -f apps/frontend/.cache/.tsbuildinfo
- cd apps/frontend && bun run type-check
- git diff --check