### PR TITLE
[codex] add Vercel backend function

### DIFF
--- a/apps/admin-frontend/next.config.ts
+++ b/apps/admin-frontend/next.config.ts
@@ -11,6 +11,10 @@ interface RemotePattern {
 }
 
 function buildImageRemotePatterns(): RemotePattern[] {
+  const staticPatterns: RemotePattern[] = [
+    { protocol: 'https', hostname: '**.public.blob.vercel-storage.com' },
+    { protocol: 'https', hostname: 'images.unsplash.com' },
+  ];
   const origins = [
     process.env.MINIO_ENDPOINT,
     process.env.MINIO_PUBLIC_URL,
@@ -37,7 +41,7 @@ function buildImageRemotePatterns(): RemotePattern[] {
       // Ignore malformed optional env values; build should still use safe defaults.
     }
   }
-  return [...patterns.values()];
+  return [...patterns.values(), ...staticPatterns];
 }
 
 const nextConfig: NextConfig = {

--- a/apps/backend/.cargo/config.toml
+++ b/apps/backend/.cargo/config.toml
@@ -1,2 +1,4 @@
 [net]
 git-fetch-with-cli = true
+
+[build]

--- a/apps/backend/.vercelignore
+++ b/apps/backend/.vercelignore
@@ -1,7 +1,7 @@
 package.json
-target
 .env
 .env.*
 Dockerfile
 *.log
 .DS_Store
+target

--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -795,6 +795,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-streams"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49debcb7f7400a7f2c96d590795c12372f4db7ad0f518d5a02286d8c8b8c691d"
+dependencies = [
+ "axum 0.8.8",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "serde",
+ "serde_json",
+ "tokio-stream",
+]
+
+[[package]]
 name = "axum-test"
 version = "15.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.6"
+version = "2.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "229850a212cd9b84d4f0290ad9d294afc0ae70fccaa8949dbe8b43ffafa1e20c"
 dependencies = [
  "bigdecimal",
  "bitflags 2.11.0",
@@ -1666,13 +1694,13 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+checksum = "51a307ac00f7c23f526a04a77761a0519b9f0eb2838ebf5b905a58580095bdcb"
 dependencies = [
  "async-trait",
  "bb8",
- "deadpool",
+ "deadpool 0.12.3",
  "diesel",
  "futures-util",
  "scoped-futures",
@@ -1682,11 +1710,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "1b96984c469425cb577bf6f17121ecb3e4fe1e81de5d8f780dd372802858d756"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1694,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -1705,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.117",
 ]
@@ -1788,6 +1817,20 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dunce"
@@ -1919,7 +1962,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
- "deadpool",
+ "deadpool 0.9.5",
  "diesel",
  "diesel-async",
  "diesel_migrations",
@@ -1935,6 +1978,7 @@ dependencies = [
  "lazy_static",
  "md5",
  "once_cell",
+ "pq-sys",
  "rand 0.8.5",
  "redis",
  "regex",
@@ -1964,6 +2008,7 @@ dependencies = [
  "utoipa",
  "uuid 1.21.0",
  "validator",
+ "vercel_runtime",
  "webpki-roots 0.26.11",
 ]
 
@@ -1980,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2990,10 +3035,13 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
+ "system-configuration 0.7.0",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3512,19 +3560,19 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "migrations_internals"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+checksum = "3bda1634d70d5bd53553cf15dca9842a396e8c799982a3ad22998dc44d961f24"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -3784,6 +3832,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -4153,11 +4213,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "pq-sys"
-version = "0.4.8"
+name = "pq-src"
+version = "0.3.11+libpq-18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
+checksum = "6fb5bfbe0c3445d371dd8acf7d6c912ece8baf2f61f7c571af85a1d7687c2d0f"
 dependencies = [
+ "cc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "pq-sys"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "pq-src",
  "vcpkg",
 ]
 
@@ -4559,7 +4632,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -4783,7 +4856,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5178,6 +5251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5553,7 +5635,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5561,6 +5654,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5582,7 +5685,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5901,26 +6004,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -5943,29 +6049,16 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -5977,7 +6070,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -5986,7 +6079,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -5994,6 +6087,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -6459,6 +6558,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vercel_runtime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49303fb373ffd4c43c023f48ec1ee860bbdea98e2b22a3fe55efa5db9fe2a80b"
+dependencies = [
+ "axum 0.8.8",
+ "axum-streams",
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6709,7 +6830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6758,6 +6879,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -6998,15 +7130,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -27,6 +27,10 @@ name = "migrate_media"
 path = "src/bin/migrate_media.rs"
 required-features = ["cli-tools"]
 
+[[bin]]
+name = "epsx_vercel"
+path = "api/epsx_vercel.rs"
+
 # Feature flags optimized for production
 [features]
 default = ["production"]
@@ -81,6 +85,7 @@ once_cell = "1.19"
 rand = "0.8"
 dashmap = "6.0"
 md5 = "0.7"  # Used in key_management for fingerprinting
+vercel_runtime = { version = "2", features = ["axum"] }
 
 # Optional WebSocket support
 futures-util = { version = "0.3", optional = true }
@@ -131,9 +136,10 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 bigdecimal = { version = "0.4", features = ["serde"] }
 
 # Diesel 2.x ORM with async support
-diesel = { version = "2.1", features = ["postgres", "uuid", "chrono", "numeric", "serde_json", "r2d2", "network-address", "32-column-tables"] }
-diesel-async = { version = "0.4", features = ["postgres", "deadpool", "async-connection-wrapper", "bb8"] }
-diesel_migrations = "2.1"
+diesel = { version = "2.2", features = ["postgres", "uuid", "chrono", "numeric", "serde_json", "r2d2", "network-address", "32-column-tables"] }
+diesel-async = { version = "0.5", features = ["postgres", "deadpool", "async-connection-wrapper", "bb8"] }
+diesel_migrations = "2.2"
+pq-sys = { version = "0.7", default-features = false, features = ["bundled"] }
 deadpool = { version = "0.9", features = ["rt_tokio_1"] }
 governor = "0.10.0"
 # Diesel provides type-safe ORM with async support via diesel-async

--- a/apps/backend/api/epsx_vercel.rs
+++ b/apps/backend/api/epsx_vercel.rs
@@ -1,0 +1,15 @@
+use tower::ServiceBuilder;
+use vercel_runtime::{axum::VercelLayer, Error};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let runtime =
+        epsx::bootstrap::build_runtime(epsx::bootstrap::BackendBootstrapOptions::vercel_function())
+            .await?;
+
+    let app = ServiceBuilder::new()
+        .layer(VercelLayer::new())
+        .service(runtime.router);
+
+    vercel_runtime::run(app).await
+}

--- a/apps/backend/src/bootstrap.rs
+++ b/apps/backend/src/bootstrap.rs
@@ -1,0 +1,187 @@
+use std::sync::{Arc, Once};
+
+use anyhow::{anyhow, Result};
+use axum::Router;
+use tracing::info;
+
+use crate::{
+    config::env::{init_config, Config},
+    infrastructure::{
+        cache::{memory_cache::MemoryCache, redis_cache::RedisCache, Cache, CacheConfig},
+        container::DomainContainer,
+        database::get_diesel_pool,
+    },
+    prelude::TlsPool,
+    web::create_router,
+};
+
+static LOGGER_INIT: Once = Once::new();
+static CRYPTO_PROVIDER_INIT: Once = Once::new();
+
+#[derive(Clone, Copy)]
+pub struct BackendBootstrapOptions {
+    pub seed_database: bool,
+    pub start_background_workers: bool,
+}
+
+impl BackendBootstrapOptions {
+    pub const fn stateful_server() -> Self {
+        Self {
+            seed_database: true,
+            start_background_workers: true,
+        }
+    }
+
+    pub const fn vercel_function() -> Self {
+        Self {
+            seed_database: false,
+            start_background_workers: false,
+        }
+    }
+}
+
+pub struct BackendRuntime {
+    pub config: Config,
+    pub container: Arc<DomainContainer>,
+    pub router: Router,
+}
+
+pub async fn build_runtime(options: BackendBootstrapOptions) -> Result<BackendRuntime> {
+    let config = init_backend_process();
+    let _db_pool = initialize_database(options.seed_database).await?;
+    let cache = initialize_cache().await;
+
+    let container = Arc::new(DomainContainer::new_with_web3_services(cache, None).await);
+
+    if options.start_background_workers {
+        start_background_workers(&container);
+    }
+
+    let router = create_router(Arc::clone(&container));
+
+    Ok(BackendRuntime {
+        config,
+        container,
+        router,
+    })
+}
+
+pub fn init_backend_process() -> Config {
+    let config = init_config();
+
+    LOGGER_INIT.call_once(|| {
+        crate::infrastructure::logger::init_logger(config.is_production(), &config.log_level);
+    });
+
+    CRYPTO_PROVIDER_INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+
+    config
+}
+
+async fn initialize_database(seed_database: bool) -> Result<&'static TlsPool> {
+    if std::env::var("DATABASE_URL").is_err() {
+        return Err(anyhow!("DATABASE_URL must be set"));
+    }
+
+    info!("Connecting to database...");
+
+    let db_pool = get_diesel_pool().await?;
+    let connection_timeout = std::time::Duration::from_secs(10);
+
+    match tokio::time::timeout(connection_timeout, db_pool.get()).await {
+        Ok(Ok(_)) => info!("Database pool created and connection verified"),
+        Ok(Err(e)) => return Err(anyhow!("Database connection failed: {}", e)),
+        Err(_) => return Err(anyhow!("Database connection timed out")),
+    }
+
+    if seed_database {
+        crate::infrastructure::services::seed_system_admin_plans(db_pool).await;
+        crate::infrastructure::services::seed_production_news(db_pool).await;
+    }
+
+    Ok(db_pool)
+}
+
+async fn initialize_cache() -> Option<Arc<dyn Cache>> {
+    let redis_timeout = std::time::Duration::from_secs(5);
+
+    match std::env::var("REDIS_URL").ok() {
+        Some(redis_url) => {
+            match tokio::time::timeout(
+                redis_timeout,
+                RedisCache::new(redis_url, 10, CacheConfig::default()),
+            )
+            .await
+            {
+                Ok(Ok(cache)) => {
+                    info!("Redis cache initialized");
+                    Some(Arc::new(cache) as Arc<dyn Cache>)
+                }
+                Ok(Err(e)) => {
+                    info!(
+                        "Redis cache initialization failed, using memory cache: {}",
+                        e
+                    );
+                    Some(Arc::new(MemoryCache::new()) as Arc<dyn Cache>)
+                }
+                Err(_) => {
+                    info!("Redis connection timed out after 5s, using memory cache");
+                    Some(Arc::new(MemoryCache::new()) as Arc<dyn Cache>)
+                }
+            }
+        }
+        None => {
+            info!("No Redis URL configured, using memory cache");
+            Some(Arc::new(MemoryCache::new()) as Arc<dyn Cache>)
+        }
+    }
+}
+
+fn start_background_workers(container: &Arc<DomainContainer>) {
+    crate::infrastructure::blockchain::spawn_transaction_monitor();
+    info!("Transaction Monitor background service started");
+
+    if let Some(dispatcher) = &container.event_dispatcher {
+        let dispatcher = Arc::clone(dispatcher);
+        tokio::spawn(async move {
+            match dispatcher.start().await {
+                Ok(_) => {
+                    info!("EventDispatcher started - events will be published to Redis Streams")
+                }
+                Err(e) => info!(
+                    "EventDispatcher failed to start: {} (continuing without event publishing)",
+                    e
+                ),
+            }
+        });
+    } else {
+        info!("EventDispatcher not configured (Redis URL not set)");
+    }
+
+    if let Some(projection_manager) = &container.projection_manager {
+        let projection_manager = Arc::clone(projection_manager);
+        tokio::spawn(async move {
+            match projection_manager.start().await {
+                Ok(_) => {
+                    info!("ProjectionManager started - read models will be updated from events")
+                }
+                Err(e) => info!(
+                    "ProjectionManager failed to start: {} (continuing without projections)",
+                    e
+                ),
+            }
+        });
+    } else {
+        info!("ProjectionManager not configured");
+    }
+
+    let svc = crate::infrastructure::services::PlanExpirationService::new(
+        Arc::clone(&container.db_pool),
+        container.notifications_pool.as_ref().map(Arc::clone),
+        container.redis_broadcaster.as_ref().map(Arc::clone),
+    );
+    svc.start();
+    info!("PlanExpirationService background service started");
+}

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -18,6 +18,7 @@ pub mod infrastructure; // Infrastructure layer with adapters and DDD patterns
 pub mod web; // Web/API layer (maintains same endpoints, uses DDD internally)
 pub mod config; // Configuration
 pub mod auth; // Web3 wallet-first authentication system
+pub mod bootstrap; // Shared runtime bootstrap for stateful and serverless entrypoints
 
 #[cfg(test)]
 pub mod __test__;

--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -1,158 +1,27 @@
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
-use epsx::prelude::{TlsPool, TlsConnectionManager};
-use tracing::{info, error};
 
-// Import from our library
-use epsx::{
-    config::env::init_config,
-    infrastructure::container::DomainContainer,
-    create_router,
-};
+use epsx::bootstrap::{build_runtime, BackendBootstrapOptions};
+use tracing::{error, info};
 
 /// Main server entry point - Unified Router Architecture
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Initialize configuration (loads .env and validates)
-    let config = init_config();
-
-    // Initialize tracing with level from configuration
-    // Uses the unified logging infrastructure
-    epsx::infrastructure::logger::init_logger(config.is_production(), &config.log_level);
-
-    // Install default crypto provider for rustls
-    let _ = rustls::crypto::ring::default_provider().install_default();
+async fn main() -> anyhow::Result<()> {
+    let runtime = build_runtime(BackendBootstrapOptions::stateful_server()).await?;
 
     info!("Starting EPSX Backend Server - Data Analytics Platform...");
-
-    // Create database pool with Diesel
-    let database_url = std::env::var("DATABASE_URL")
-        .map_err(|_| "DATABASE_URL must be set")?;
-
-    info!("Connecting to database...");
-    let db_config = TlsConnectionManager::new(database_url);
-    let pool = TlsPool::builder(db_config)
-        .max_size(10)
-        .runtime(deadpool::Runtime::Tokio1)
-        .build()
-        .map_err(|e| format!("Failed to create database pool: {}", e))?;
-
-    // Test database connection with timeout
-    let connection_timeout = std::time::Duration::from_secs(10);
-    match tokio::time::timeout(connection_timeout, pool.get()).await {
-        Ok(Ok(_)) => {
-            info!("Database pool created and connection verified")
-        },
-        Ok(Err(e)) => {
-            error!("Failed to connect to database: {}", e);
-            return Err(format!("Database connection failed: {}", e).into());
-        },
-        Err(_) => {
-            error!("Database connection check timed out after 10s");
-            return Err("Database connection timed out".into());
-        }
-    }
-
-    // Leak the pool to make it 'static (required for container)
-    let _db_pool: &'static TlsPool = Box::leak(Box::new(pool));
-
-    // Seed system admin plans (idempotent)
-    epsx::infrastructure::services::seed_system_admin_plans(_db_pool).await;
-
-    // Seed production news (idempotent)
-    epsx::infrastructure::services::seed_production_news(_db_pool).await;
-
-    // Create cache (optional)
-    let redis_timeout = std::time::Duration::from_secs(5);
-    let cache = match std::env::var("REDIS_URL").ok() {
-        Some(redis_url) => {
-            match tokio::time::timeout(redis_timeout, epsx::infrastructure::cache::redis_cache::RedisCache::new(
-                redis_url,
-                10, // pool_size
-                epsx::infrastructure::cache::CacheConfig::default()
-            )).await {
-                Ok(Ok(cache)) => {
-                    info!("Redis cache initialized");
-                    Some(Arc::new(cache) as Arc<dyn epsx::infrastructure::cache::Cache>)
-                }
-                Ok(Err(e)) => {
-                    info!("Redis cache initialization failed, using memory cache: {}", e);
-                    Some(Arc::new(epsx::infrastructure::cache::memory_cache::MemoryCache::new())
-                        as Arc<dyn epsx::infrastructure::cache::Cache>)
-                }
-                Err(_) => {
-                    info!("Redis connection timed out after 5s, using memory cache");
-                    Some(Arc::new(epsx::infrastructure::cache::memory_cache::MemoryCache::new())
-                        as Arc<dyn epsx::infrastructure::cache::Cache>)
-                }
-            }
-        }
-        None => {
-            info!("No Redis URL configured, using memory cache");
-            Some(Arc::new(epsx::infrastructure::cache::memory_cache::MemoryCache::new())
-                as Arc<dyn epsx::infrastructure::cache::Cache>)
-        }
-    };
-
-    // Create domain container with Web3 services
-    let container = Arc::new(DomainContainer::new_with_web3_services(
-        cache,
-        None, // blockchain_config - will use defaults
-    ).await);
-    info!("Domain container initialized with Web3 services and Redis notifications");
-
-    // Start Transaction Monitor Service (Background task for verifying payments)
-    epsx::infrastructure::blockchain::spawn_transaction_monitor();
-    info!("Transaction Monitor background service started");
-
-    // Start EventDispatcher (background worker for publishing events to Redis)
-    if let Some(dispatcher) = &container.event_dispatcher {
-        match dispatcher.clone().start().await {
-            Ok(_) => info!("EventDispatcher started - events will be published to Redis Streams"),
-            Err(e) => info!("EventDispatcher failed to start: {} (continuing without event publishing)", e),
-        }
-    } else {
-        info!("EventDispatcher not configured (Redis URL not set)");
-    }
-
-    // Start ProjectionManager (background worker for updating read models)
-    if let Some(projection_manager) = &container.projection_manager {
-        match projection_manager.clone().start().await {
-            Ok(_) => info!("ProjectionManager started - read models will be updated from events"),
-            Err(e) => info!("ProjectionManager failed to start: {} (continuing without projections)", e),
-        }
-    } else {
-        info!("ProjectionManager not configured");
-    }
-
-    // Start PlanExpirationService (background task for expiry notifications + cleanup)
-    {
-        let svc = epsx::infrastructure::services::PlanExpirationService::new(
-            Arc::clone(&container.db_pool),
-            container.notifications_pool.as_ref().map(Arc::clone),
-            container.redis_broadcaster.as_ref().map(Arc::clone),
-        );
-        svc.start();
-        info!("PlanExpirationService background service started");
-    }
-
-    // Create unified router
-    let app = create_router(container);
     info!("Unified router created successfully");
 
-    // Server configuration using unified config
     let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| "8080".to_string())
         .parse()
         .unwrap_or(8080);
-    let host_ip: IpAddr = host
-        .parse()
-        .unwrap_or_else(|_| IpAddr::from([0, 0, 0, 0]));
+    let host_ip: IpAddr = host.parse().unwrap_or_else(|_| IpAddr::from([0, 0, 0, 0]));
 
-    info!("Backend URL: {}", config.backend_url);
-    info!("Frontend URL: {}", config.frontend_url);
-    info!("Admin URL: {}", config.admin_frontend_url);
+    info!("Backend URL: {}", runtime.config.backend_url);
+    info!("Frontend URL: {}", runtime.config.frontend_url);
+    info!("Admin URL: {}", runtime.config.admin_frontend_url);
+
     let addr = SocketAddr::new(host_ip, port);
 
     info!("Server starting on {}:{}", host, port);
@@ -162,16 +31,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("   Auth:      http://{}:{}/api/auth/web3/*", host, port);
     info!("   Analytics: http://{}:{}/api/analytics/*", host, port);
     info!("   Public:    http://{}:{}/api/public/*", host, port);
-    info!("   Admin:     http://{}:{}/admin/* | http://{}:{}/api/admin/*", host, port, host, port);
+    info!(
+        "   Admin:     http://{}:{}/admin/* | http://{}:{}/api/admin/*",
+        host, port, host, port
+    );
     info!("   Docs:      http://{}:{}/docs", host, port);
     info!("");
 
-    // Start the server
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     info!("EPSX Backend Server is ready and listening!");
-    
-    match axum::serve(listener, app).await {
+
+    match axum::serve(listener, runtime.router).await {
         Ok(_) => {
             info!("Server shutdown gracefully");
             Ok(())

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "",
+  "buildCommand": "true",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "development": true
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/epsx_vercel"
+    }
+  ]
+}

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -9,6 +9,10 @@ interface RemotePattern {
 }
 
 function buildImageRemotePatterns(): RemotePattern[] {
+  const staticPatterns: RemotePattern[] = [
+    { protocol: 'https', hostname: '**.public.blob.vercel-storage.com' },
+    { protocol: 'https', hostname: 'images.unsplash.com' },
+  ];
   const origins = [
     process.env.MINIO_ENDPOINT,
     process.env.MINIO_PUBLIC_URL,
@@ -35,7 +39,7 @@ function buildImageRemotePatterns(): RemotePattern[] {
       // Ignore malformed optional env values; build should still use safe defaults.
     }
   }
-  return [...patterns.values()];
+  return [...patterns.values(), ...staticPatterns];
 }
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
- adds a Vercel Rust Function entrypoint for the backend under `apps/backend/api/epsx_vercel.rs`
- extracts shared backend startup into `epsx::bootstrap` so the existing stateful Axum server and Vercel function use the same router setup
- disables long-running background workers and seed jobs for the Vercel serverless entrypoint
- adds backend-local `vercel.json` routing for the Vercel function
- updates Diesel/libpq dependencies so Vercel can build the Rust function without a system `libpq` package

## External deployment state
- created/linked the Vercel project `epsx-backend`
- configured Preview environment variables against a Neon development branch
- restored the current development PostgreSQL databases into Neon development databases for backend preview testing
- deployed the backend Preview successfully: https://epsx-backend-kiz0m6xzi-info-epsxs-projects.vercel.app

## Validation
- `cargo check --manifest-path apps/backend/Cargo.toml --bin epsx --bin epsx_vercel`
- `rustfmt --edition 2021 apps/backend/src/bootstrap.rs apps/backend/src/main.rs apps/backend/api/epsx_vercel.rs`
- `VERCEL_BUILD_IMAGE=1 vercel build --debug`
- `vercel inspect https://epsx-backend-kiz0m6xzi-info-epsxs-projects.vercel.app` reports `Ready`
- `vercel curl /health --deployment https://epsx-backend-kiz0m6xzi-info-epsxs-projects.vercel.app` returns `status: healthy` with primary, analytics, notifications, and payments databases healthy

## Notes
- Draft PR only; not merged.
- Production deployment was not kept for this backend refactor path.
